### PR TITLE
feat: tp install-hooks, tp reap, tp ls --fzf

### DIFF
--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -6,7 +6,9 @@ import argparse
 import json
 import sys
 
-from . import core, display
+from pathlib import Path
+
+from . import core, display, hooks
 
 
 def cmd_ls(args: argparse.Namespace) -> None:
@@ -17,6 +19,8 @@ def cmd_ls(args: argparse.Namespace) -> None:
     )
     if args.json:
         print(json.dumps([s.to_dict() for s in sessions], indent=2))
+    elif args.fzf:
+        print(display.format_fzf(sessions, cols=args.cols))
     else:
         print(display.format_session_table(sessions, cols=args.cols))
 
@@ -128,6 +132,71 @@ def cmd_get(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def cmd_install_hooks(args: argparse.Namespace) -> None:
+    hooks_dir = Path(args.path) if args.path else None
+    if args.uninstall:
+        actions = hooks.uninstall_hooks(hooks_dir)
+        for h in actions["hooks_removed"]:
+            print(f"  removed {h}")
+        if actions["restored_hooks_path"]:
+            print(f"  restored core.hooksPath -> {actions['restored_hooks_path']}")
+        else:
+            print("  unset core.hooksPath")
+        print("Uninstalled tmux-pilot hooks.")
+    else:
+        actions = hooks.install_hooks(hooks_dir)
+        for h in actions["hooks_installed"]:
+            print(f"  installed {h}")
+        print(f"Hooks in {actions['hooks_dir']}, core.hooksPath configured.")
+
+
+def cmd_reap(args: argparse.Namespace) -> None:
+    from . import reaper
+    results = reaper.reap_sessions(
+        dry_run=args.dry_run,
+        force=args.force,
+        include_no_pr=args.include_no_pr,
+    )
+    if not results:
+        print("No sessions to reap.")
+        return
+
+    if args.dry_run:
+        print("Dry run -- would reap:")
+        for r in results:
+            flag = r.get("reason", "")
+            print(f"  {r['session']}  branch={r.get('branch', '?')}  pr=#{r.get('pr', '-')}  [{flag}]")
+        return
+
+    if not args.force:
+        names = ", ".join(r["session"] for r in results if r.get("action") == "confirm")
+        if names:
+            resp = input(f"Reap session(s): {names}? [y/N] ")
+            if resp.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return
+            # Actually reap after confirmation
+            results = reaper.reap_sessions(
+                dry_run=False,
+                force=True,
+                include_no_pr=args.include_no_pr,
+            )
+
+    for r in results:
+        parts = [r["session"]]
+        if r.get("killed"):
+            parts.append("killed")
+        if r.get("worktree_removed"):
+            parts.append("worktree removed")
+        if r.get("branch_deleted"):
+            parts.append("branch deleted")
+        if r.get("skipped"):
+            parts.append(f"skipped ({r.get('reason', '')})")
+        print("  ".join(parts))
+    reaped = sum(1 for r in results if r.get("killed"))
+    print(f"Reaped {reaped} session(s).")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tp",
@@ -144,6 +213,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ls = sub.add_parser("ls", help="List sessions with metadata")
     p_ls.add_argument("--json", action="store_true", help="Output as JSON")
     p_ls.add_argument("--cols", help="Columns to show: mnemonics (NSP) or names (NAME,STATUS,PROCESS)")
+    p_ls.add_argument("--fzf", action="store_true", help="Tab-separated output for fzf piping")
     p_ls.add_argument("--status", help="Filter by status (e.g. active, done)")
     p_ls.add_argument("--repo", help="Filter by repo name (substring match)")
     p_ls.add_argument("--process", help="Filter by process (e.g. claude-code, python)")
@@ -194,6 +264,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_get.add_argument("name", help="Session name")
     p_get.add_argument("key", help="Metadata key")
 
+    # install-hooks
+    p_hooks = sub.add_parser("install-hooks", help="Install git hooks for session lifecycle")
+    p_hooks.add_argument("--path", help="Custom hooks directory (default: ~/.config/git/hooks/)")
+    p_hooks.add_argument("--uninstall", action="store_true", help="Remove hooks and restore previous hooksPath")
+
+    # reap
+    p_reap = sub.add_parser("reap", help="Reap sessions whose PRs are merged")
+    p_reap.add_argument("--dry-run", action="store_true", help="Preview without executing")
+    p_reap.add_argument("--force", action="store_true", help="Skip confirmation prompt")
+    p_reap.add_argument("--include-no-pr", action="store_true", help="Also flag clean sessions with no PR")
+
     return parser
 
 
@@ -221,6 +302,8 @@ def main(argv: list[str] | None = None) -> None:
         "kill": cmd_kill,
         "set": cmd_set,
         "get": cmd_get,
+        "install-hooks": cmd_install_hooks,
+        "reap": cmd_reap,
     }
     handlers[args.command](args)
 

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 # Metadata keys stored as tmux user options (@-prefixed)
-METADATA_KEYS = ("repo", "task", "desc", "status", "origin", "branch", "needs")
+METADATA_KEYS = ("repo", "task", "desc", "status", "origin", "branch", "needs", "last_commit", "pr", "pr_state", "pushing")
 
 # Map pane_current_command to friendly process names
 PROCESS_ALIASES: dict[str, str] = {

--- a/src/tmux_pilot/display.py
+++ b/src/tmux_pilot/display.py
@@ -14,6 +14,8 @@ ALL_COLUMNS: list[tuple[str, str, object]] = [
     ("REPO", "R", lambda s: _shorten_path(s.metadata.get("repo", "")) or "-"),
     ("TASK", "T", lambda s: s.metadata.get("task", "") or "-"),
     ("BRANCH", "B", lambda s: s.metadata.get("branch", "") or "-"),
+    ("PR", "G", lambda s: s.metadata.get("pr", "") or "-"),
+    ("PR_STATE", "X", lambda s: s.metadata.get("pr_state", "") or "-"),
 ]
 
 _COL_BY_MNEMONIC = {m: (name, acc) for name, m, acc in ALL_COLUMNS}
@@ -81,6 +83,24 @@ def format_session_table(sessions: list[SessionInfo], cols: str | None = None) -
     for row in rows:
         lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)))
 
+    return "\n".join(lines)
+
+
+def format_fzf(sessions: list[SessionInfo], cols: str | None = None) -> str:
+    """Format sessions as tab-separated lines for fzf piping.
+
+    First field is the raw session name (for selection), remaining
+    fields are the human-readable column values.
+    """
+    if not sessions:
+        return ""
+
+    columns = parse_cols(cols)
+    accessors = [acc for _, acc in columns]
+    lines = []
+    for s in sessions:
+        fields = [s.name] + [acc(s) for acc in accessors]
+        lines.append("\t".join(fields))
     return "\n".join(lines)
 
 

--- a/src/tmux_pilot/hooks.py
+++ b/src/tmux_pilot/hooks.py
@@ -1,0 +1,168 @@
+"""Git hook installation for tmux-pilot session lifecycle."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+DEFAULT_HOOKS_DIR = Path.home() / ".config" / "git" / "hooks"
+
+# Marker so we can identify our hooks
+_MARKER = "# tmux-pilot managed hook"
+
+_POST_COMMIT = f"""\
+#!/bin/sh
+{_MARKER}
+# Updates @branch and @last_commit on the current tmux session.
+
+if [ -n "$TMUX" ] && command -v tp >/dev/null 2>&1; then
+    _session=$(tmux display-message -p '#S')
+    _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    _commit=$(git rev-parse --short HEAD 2>/dev/null)
+    tp set "$_session" branch "$_branch" 2>/dev/null
+    tp set "$_session" last_commit "$_commit" 2>/dev/null
+fi
+
+# Chain with previous hook
+_chain="$(dirname "$0")/post-commit.pre-tp"
+[ -x "$_chain" ] && exec "$_chain" "$@"
+"""
+
+_POST_CHECKOUT = f"""\
+#!/bin/sh
+{_MARKER}
+# Updates @branch on the current tmux session.
+
+if [ -n "$TMUX" ] && command -v tp >/dev/null 2>&1; then
+    _session=$(tmux display-message -p '#S')
+    _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    tp set "$_session" branch "$_branch" 2>/dev/null
+fi
+
+# Chain with previous hook
+_chain="$(dirname "$0")/post-checkout.pre-tp"
+[ -x "$_chain" ] && exec "$_chain" "$@"
+"""
+
+_PRE_PUSH = f"""\
+#!/bin/sh
+{_MARKER}
+# Sets @pushing=true on the current tmux session.
+
+if [ -n "$TMUX" ] && command -v tp >/dev/null 2>&1; then
+    _session=$(tmux display-message -p '#S')
+    tp set "$_session" pushing true 2>/dev/null
+fi
+
+# Chain with previous hook
+_chain="$(dirname "$0")/pre-push.pre-tp"
+[ -x "$_chain" ] && exec "$_chain" "$@"
+"""
+
+HOOKS: dict[str, str] = {
+    "post-commit": _POST_COMMIT,
+    "post-checkout": _POST_CHECKOUT,
+    "pre-push": _PRE_PUSH,
+}
+
+_SAVED_PATH_FILE = ".tp-previous-hookspath"
+
+
+def _get_hooks_path_config() -> str:
+    """Get the current global core.hooksPath, or empty string."""
+    result = subprocess.run(
+        ["git", "config", "--global", "core.hooksPath"],
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _set_hooks_path_config(path: str) -> None:
+    """Set global core.hooksPath."""
+    subprocess.run(
+        ["git", "config", "--global", "core.hooksPath", path],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _unset_hooks_path_config() -> None:
+    """Unset global core.hooksPath."""
+    subprocess.run(
+        ["git", "config", "--global", "--unset", "core.hooksPath"],
+        capture_output=True, text=True,
+    )
+
+
+def _is_tp_hook(path: Path) -> bool:
+    """Check if a hook file was written by tmux-pilot."""
+    if not path.is_file():
+        return False
+    return _MARKER in path.read_text()
+
+
+def install_hooks(hooks_dir: Path | None = None) -> dict:
+    """Install git hooks and configure core.hooksPath.
+
+    Returns dict with keys: hooks_installed, hooks_dir.
+    """
+    hdir = hooks_dir or DEFAULT_HOOKS_DIR
+    hdir.mkdir(parents=True, exist_ok=True)
+
+    # Save previous core.hooksPath so we can restore on uninstall
+    previous = _get_hooks_path_config()
+    if previous and str(Path(previous).resolve()) != str(hdir.resolve()):
+        (hdir / _SAVED_PATH_FILE).write_text(previous)
+
+    installed = []
+    for name, content in HOOKS.items():
+        hook_path = hdir / name
+        # If there's an existing non-tp hook, preserve it for chaining
+        if hook_path.is_file() and not _is_tp_hook(hook_path):
+            chain_path = hdir / f"{name}.pre-tp"
+            hook_path.rename(chain_path)
+        hook_path.write_text(content)
+        hook_path.chmod(0o755)
+        installed.append(name)
+
+    _set_hooks_path_config(str(hdir))
+
+    return {
+        "hooks_installed": installed,
+        "hooks_dir": str(hdir),
+    }
+
+
+def uninstall_hooks(hooks_dir: Path | None = None) -> dict:
+    """Remove tmux-pilot hooks and restore previous core.hooksPath.
+
+    Returns dict with keys: hooks_removed, restored_hooks_path.
+    """
+    hdir = hooks_dir or DEFAULT_HOOKS_DIR
+    removed = []
+    for name in HOOKS:
+        hook_path = hdir / name
+        if hook_path.is_file() and _is_tp_hook(hook_path):
+            hook_path.unlink()
+            removed.append(name)
+            # Restore chained hook if it exists
+            chain_path = hdir / f"{name}.pre-tp"
+            if chain_path.is_file():
+                chain_path.rename(hook_path)
+
+    # Restore previous core.hooksPath
+    saved_file = hdir / _SAVED_PATH_FILE
+    restored = ""
+    if saved_file.is_file():
+        restored = saved_file.read_text().strip()
+        saved_file.unlink()
+        if restored:
+            _set_hooks_path_config(restored)
+        else:
+            _unset_hooks_path_config()
+    else:
+        _unset_hooks_path_config()
+
+    return {
+        "hooks_removed": removed,
+        "restored_hooks_path": restored,
+    }

--- a/src/tmux_pilot/reaper.py
+++ b/src/tmux_pilot/reaper.py
@@ -1,0 +1,127 @@
+"""Reap tmux sessions whose PRs are merged."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from . import core
+
+
+def _gh_pr_status(branch: str) -> dict | None:
+    """Query GitHub for PR status on a branch.
+
+    Returns dict with 'number' and 'state', or None if no PR found.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "list", "--head", branch, "--state", "all",
+         "--json", "number,state", "--limit", "1"],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    prs = json.loads(result.stdout)
+    if not prs:
+        return None
+    return {"number": prs[0]["number"], "state": prs[0]["state"]}
+
+
+def _has_uncommitted(working_dir: str) -> bool:
+    """Check if a working directory has uncommitted changes."""
+    result = subprocess.run(
+        ["git", "-C", working_dir, "status", "--porcelain"],
+        capture_output=True, text=True, timeout=5,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def reap_sessions(
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    include_no_pr: bool = False,
+) -> list[dict]:
+    """Identify and reap sessions whose PRs are merged.
+
+    For each session with a branch, queries GitHub PR status.
+    MERGED PRs trigger reaping (kill session, remove worktree, delete branch).
+    Sessions with uncommitted changes are skipped unless --force.
+
+    Returns list of action dicts.
+    """
+    sessions = core.list_sessions()
+    results: list[dict] = []
+
+    for s in sessions:
+        branch = s.metadata.get("branch", "")
+        if not branch:
+            continue
+
+        working_dir = s.working_dir
+
+        # Query PR status
+        pr_info = _gh_pr_status(branch)
+
+        # Cache PR info on the session
+        if pr_info and not dry_run:
+            core.set_metadata(s.name, "pr", str(pr_info["number"]))
+            core.set_metadata(s.name, "pr_state", pr_info["state"])
+
+        action: dict = {
+            "session": s.name,
+            "branch": branch,
+            "pr": pr_info["number"] if pr_info else None,
+            "pr_state": pr_info["state"] if pr_info else None,
+            "killed": False,
+            "worktree_removed": False,
+            "branch_deleted": False,
+            "skipped": False,
+            "reason": "",
+        }
+
+        # Decide whether to reap
+        should_reap = False
+        if pr_info and pr_info["state"] == "MERGED":
+            should_reap = True
+            action["reason"] = "pr-merged"
+        elif not pr_info and include_no_pr:
+            should_reap = True
+            action["reason"] = "no-pr"
+        else:
+            if pr_info:
+                action["reason"] = f"pr-{pr_info['state'].lower()}"
+            else:
+                action["reason"] = "no-pr"
+            action["skipped"] = True
+            # Only include in results if it would be actionable
+            if not include_no_pr and not pr_info:
+                continue
+            results.append(action)
+            continue
+
+        # Check for uncommitted changes
+        if working_dir and _has_uncommitted(working_dir) and not force:
+            action["skipped"] = True
+            action["reason"] = "uncommitted-changes"
+            results.append(action)
+            continue
+
+        if dry_run:
+            action["action"] = "confirm"
+            results.append(action)
+            continue
+
+        # Actually reap
+        core.kill_session(s.name)
+        action["killed"] = True
+
+        if working_dir and core._is_git_worktree(working_dir):
+            action["worktree_removed"] = core._remove_worktree(working_dir)
+
+        if branch and working_dir:
+            repo = s.metadata.get("repo", working_dir)
+            action["branch_deleted"] = core._delete_branch(repo, branch)
+
+        results.append(action)
+
+    return results

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -310,7 +310,7 @@ class TestDisplay:
 
     def test_parse_cols_invalid_mnemonic(self):
         with pytest.raises(ValueError, match="Unknown column mnemonic"):
-            parse_cols("NXP")
+            parse_cols("NZP")
 
     def test_parse_cols_invalid_name(self):
         with pytest.raises(ValueError, match="Unknown column"):


### PR DESCRIPTION
Implements #9

- **tp install-hooks**: sets up global git hooks via `core.hooksPath`. Installs post-commit, post-checkout, pre-push hooks that update session metadata (@branch, @last_commit, @pushing)
- **tp reap**: cross-references worktree branches against GitHub PR state via `gh pr list`. MERGED → reap, uncommitted → skip. Supports --dry-run, --force, --include-no-pr
- **tp ls --fzf**: tab-separated output for fzf piping (name<tab>process branch desc)
- New metadata keys: branch, last_commit, pr, pr_state