### PR TITLE
[codex] Track last_send on tp send

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ tp status NAME
 
 ### `tp set` / `tp get` — Session metadata
 
-Metadata is stored as tmux user options (`@`-prefixed). Built-in keys: `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`.
+Metadata is stored as tmux user options (`@`-prefixed). Built-in keys: `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, `last_send`.
 
 ```bash
 tp set NAME status "waiting-for-review"

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ tp status NAME
 
 ### `tp set` / `tp get` — Session metadata
 
-Metadata is stored as tmux user options (`@`-prefixed). Built-in keys: `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, `last_send`.
+Metadata is stored as tmux user options (`@`-prefixed). Common built-in keys include `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, and `last_send`.
 
 ```bash
 tp set NAME status "waiting-for-review"

--- a/docs/reference/agent-state.md
+++ b/docs/reference/agent-state.md
@@ -15,6 +15,8 @@ Behavior:
 - sends the text only after readiness is confirmed
 - raises an error if the timeout is reached first
 
+Every successful `tp send` also records a sortable UTC timestamp in the session metadata as `last_send`.
+
 ## State values
 
 Current built-in states:
@@ -37,6 +39,14 @@ States that are not first-class yet:
 - trust prompt
 - shell idle
 - exited
+
+## Metadata
+
+`tp` stores session metadata as tmux user options.
+
+Relevant keys for steering:
+
+- `last_send`: updated after a successful `tp send`
 
 ## Transcript sources
 

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 try:
@@ -17,7 +18,20 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
     import tomli as tomllib  # type: ignore[import-not-found]
 
 # Metadata keys stored as tmux user options (@-prefixed)
-METADATA_KEYS = ("repo", "task", "desc", "status", "origin", "branch", "needs", "last_commit", "pr", "pr_state", "pushing")
+METADATA_KEYS = (
+    "repo",
+    "task",
+    "desc",
+    "status",
+    "origin",
+    "branch",
+    "needs",
+    "last_commit",
+    "last_send",
+    "pr",
+    "pr_state",
+    "pushing",
+)
 
 # Map pane_current_command to friendly process names
 PROCESS_ALIASES: dict[str, str] = {
@@ -314,6 +328,11 @@ def set_metadata(session_name: str, key: str, value: str) -> None:
     _tmux("set-option", "-t", session_name, f"@{key}", value)
 
 
+def _metadata_timestamp() -> str:
+    """Return a UTC timestamp suitable for sortable tmux metadata."""
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
 def new_session(
     name: str,
     *,
@@ -429,6 +448,7 @@ def send_text(
     if wait:
         agent = wait_until_session_ready(name, timeout=timeout, interval=interval)
     send_keys(name, text)
+    set_metadata(name, "last_send", _metadata_timestamp())
     return agent
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -347,11 +347,14 @@ class TestPeekAndSend:
         core.new_session(TEST_SESSION)
         assert core.peek_session(TEST_SESSION, lines=10) == ""
 
-    def test_send_and_peek(self, fake_tmux: FakeTmux):
+    def test_send_text_sets_last_send_and_peek(self, fake_tmux: FakeTmux):
         core.new_session(TEST_SESSION)
-        core.send_keys(TEST_SESSION, "echo TMUX_PILOT_TEST_MARKER")
+        core.send_text(TEST_SESSION, "echo TMUX_PILOT_TEST_MARKER")
         output = core.peek_session(TEST_SESSION, lines=20)
         assert "TMUX_PILOT_TEST_MARKER" in output
+        last_send = fake_tmux.sessions[TEST_SESSION]["metadata"]["last_send"]
+        assert isinstance(last_send, str)
+        assert last_send.endswith("Z")
 
     def test_send_uses_literal_text_then_enter(self, fake_tmux: FakeTmux, monkeypatch: pytest.MonkeyPatch):
         sleeps: list[float] = []
@@ -392,6 +395,7 @@ class TestPeekAndSend:
             (TEST_SESSION, True, ["echo waited"]),
             (TEST_SESSION, False, ["Enter"]),
         ]
+        assert fake_tmux.sessions[TEST_SESSION]["metadata"]["last_send"].endswith("Z")
 
 
 class TestWaitForReady:

--- a/tests/test_send_keys_tmux.py
+++ b/tests/test_send_keys_tmux.py
@@ -130,7 +130,9 @@ def wait_for_mock_codex_prompt(session_name: str, *, timeout: float = 3.0) -> st
     def has_prompt() -> bool:
         nonlocal output
         output = core.peek_session(session_name, lines=200)
-        if "gpt-5.4 xhigh" in output:
+        # Narrow tmux panes can soft-wrap the status line, splitting "gpt-5.4"
+        # across lines in capture-pane output.
+        if "gpt-5.4xhigh" in "".join(output.split()):
             return True
         if "Press enter" in output:
             core.send_keys(session_name, "1")


### PR DESCRIPTION
## Summary
- add `last_send` to the tmux metadata surfaced by `tp ls --json` and `tp status`
- stamp `@last_send` with a sortable UTC timestamp after each successful `tp send`
- document the metadata key in the README and reference docs
- keep the Codex tmux prompt assertion stable when the status line soft-wraps in narrow panes

## Why
SwiftMux needs a recency signal that lives in the `tp` layer rather than in app-local UI state. Before this change, `tp` had no metadata indicating when a session was last steered.

## Validation
- `uv run ruff check`
- `uv run pytest -q` (`117 passed`)