### PR TITLE
[codex] Add profiles and task worktree bootstrap

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     permissions:
       contents: read
       pull-requests: read
@@ -19,10 +22,16 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Skip when Claude credentials are unavailable
+        if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN == '' && env.ANTHROPIC_API_KEY == '' }}
+        run: echo "Skipping Claude Code review because no Claude credentials are configured."
+
       - name: Run Claude Code Review
+        if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' || env.ANTHROPIC_API_KEY != '' }}
         uses: anthropics/claude-code-action@beta
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/README.md
+++ b/README.md
@@ -22,13 +22,25 @@ uv tool install tmux-pilot
 ## Quick Start
 
 ```bash
-# Start Codex in the current repo with the built-in `codex` profile
+# Start Codex in an existing checkout.
+# tmux-pilot runs: codex --profile yolo
 tp new auth-flow --profile codex -c ~/repos/myapp
 
-# Bootstrap a task branch + worktree from a local repo, then launch Claude Code
-tp new oauth-fix --profile claude --repo ~/repos/myapp -d "Fix OAuth callback handling"
+# Start Claude Code in an existing checkout.
+# tmux-pilot runs: claude --permission-mode bypassPermissions
+tp new review-pass --profile claude -c ~/repos/myapp
 
-# Bootstrap from GitHub if the repo is not cloned locally yet
+# Start Pi in an existing checkout.
+# tmux-pilot runs: pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
+tp new pi-local --profile pi -c ~/repos/pi-mono
+
+# Bootstrap a task branch + worktree from a local repo, then launch Codex there.
+# Default branch: feat/oauth-fix
+# Default worktree: ~/worktrees/myapp-oauth-fix
+tp new oauth-fix --profile codex --repo ~/repos/myapp -d "Fix OAuth callback handling"
+
+# Bootstrap from GitHub if the repo is not cloned locally yet.
+# The repo is cloned to ~/repos/pi-mono first, then a worktree is created.
 tp new pi-smoke --profile pi --repo badlogic/pi-mono
 
 # Check on all your sessions
@@ -53,6 +65,7 @@ Detailed documentation lives under [`docs/`](./docs/README.md) and is organized 
 
 - tutorial: [`docs/tutorials/drive-a-kept-alive-agent-session.md`](./docs/tutorials/drive-a-kept-alive-agent-session.md)
 - how-to: [`docs/how-to/wait-for-interactive-agents.md`](./docs/how-to/wait-for-interactive-agents.md)
+- how-to: [`docs/how-to/start-task-sessions-with-profiles-and-worktrees.md`](./docs/how-to/start-task-sessions-with-profiles-and-worktrees.md)
 - explanation: [`docs/explanation/file-backed-agent-state.md`](./docs/explanation/file-backed-agent-state.md)
 - reference: [`docs/reference/agent-state.md`](./docs/reference/agent-state.md)
 
@@ -92,12 +105,46 @@ tp new NAME --profile codex --repo ~/repos/myapp --branch chore/name-cleanup
 tp new NAME --profile codex --repo ~/repos/myapp --base-ref origin/release/1.2
 ```
 
+Concrete profile examples:
+
+```bash
+# Launches `codex --profile yolo` in ~/repos/myapp
+tp new auth-pass --profile codex -c ~/repos/myapp
+
+# Launches `claude --permission-mode bypassPermissions` in ~/repos/myapp
+tp new review-pass --profile claude -c ~/repos/myapp
+
+# Launches `pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
+tp new pi-local --profile pi -c ~/repos/pi-mono
+```
+
 When `--repo` is used, `tp new` now handles the full task bootstrap flow:
 
 - resolves or clones the repo
 - derives a task branch from the session name (or `--issue`)
 - creates a git worktree under the configured worktree base
 - starts the requested agent inside that worktree
+
+Concrete bootstrap examples:
+
+```bash
+# Creates branch `feat/oauth-fix`, worktree `~/worktrees/myapp-oauth-fix`,
+# then launches `codex --profile yolo` inside that worktree.
+tp new oauth-fix --profile codex --repo ~/repos/myapp
+
+# Creates branch `fix/771-issue-771`, fetches the issue title for @desc,
+# then launches `claude --permission-mode bypassPermissions`.
+tp new issue-771 --profile claude --repo ~/repos/myapp --issue 771
+
+# If ~/repos/pi-mono does not exist yet, clone it first.
+# Then create branch `feat/pi-smoke`, worktree `~/worktrees/pi-mono-pi-smoke`,
+# and launch Pi with a worktree-local session dir.
+tp new pi-smoke --profile pi --repo badlogic/pi-mono
+
+# Pin the branch name or starting point when needed.
+tp new cleanup --profile codex --repo ~/repos/myapp --branch chore/cleanup
+tp new backport --profile codex --repo ~/repos/myapp --base-ref origin/release/1.2
+```
 
 Built-in launch profiles:
 
@@ -113,10 +160,8 @@ extends = "codex"
 worktree_base = "~/worktrees"
 clone_base = "~/repos"
 
-[profiles.claude]
-worktree_base = "~/worktrees"
-
 [profiles.pi]
+extends = "pi"
 branch_prefix = "task"
 
 [profiles.myapp]
@@ -127,6 +172,22 @@ base_ref = "origin/main"
 ```
 
 `extends` can target another configured profile or one of the built-in profiles above. Config values override the inherited profile, so you can keep reusable agent defaults separate from repo-specific task defaults.
+
+Concrete config-driven examples:
+
+```bash
+# Uses `[default]`, so this launches `codex --profile yolo`
+# even though no `--profile` flag was passed.
+tp new rename-types -c ~/repos/myapp
+
+# Uses the repo/base branch from `[profiles.myapp]`,
+# so `--repo ~/repos/myapp` is not needed here.
+tp new api-cleanup --profile myapp
+
+# Uses the customized Pi profile, so the derived branch is `task/pi-smoke`
+# instead of the default `feat/pi-smoke`.
+tp new pi-smoke --profile pi --repo badlogic/pi-mono
+```
 
 ### `tp peek` — View scrollback without attaching
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ tp kill auth-flow
 Detailed documentation lives under [`docs/`](./docs/README.md) and is organized using Diataxis:
 
 - tutorial: [`docs/tutorials/drive-a-kept-alive-agent-session.md`](./docs/tutorials/drive-a-kept-alive-agent-session.md)
+- how-to: [`docs/how-to/create-sessions.md`](./docs/how-to/create-sessions.md)
 - how-to: [`docs/how-to/wait-for-interactive-agents.md`](./docs/how-to/wait-for-interactive-agents.md)
 - how-to: [`docs/how-to/start-task-sessions-with-profiles-and-worktrees.md`](./docs/how-to/start-task-sessions-with-profiles-and-worktrees.md)
 - explanation: [`docs/explanation/file-backed-agent-state.md`](./docs/explanation/file-backed-agent-state.md)
 - reference: [`docs/reference/agent-state.md`](./docs/reference/agent-state.md)
+- reference: [`docs/reference/session-creation.md`](./docs/reference/session-creation.md)
 
 ## Commands
 
@@ -87,6 +89,10 @@ tp ls --json --status active   # combine filters with JSON
 ```bash
 tp new NAME                    # bare session
 tp new NAME -c ~/repos/myapp   # set working directory + @repo
+tp new -c ~/repos/myapp        # infer session name from the directory
+tp new NAME --here             # use cwd and infer repo/branch/worktree metadata
+tp new --here                  # infer the session name from cwd/worktree
+tp new NAME --here -j          # create, then auto-jump into the session
 tp new NAME -d "description"   # set @desc metadata
 tp new NAME -c DIR -d DESC     # both
 
@@ -172,6 +178,10 @@ base_ref = "origin/main"
 ```
 
 `extends` can target another configured profile or one of the built-in profiles above. Config values override the inherited profile, so you can keep reusable agent defaults separate from repo-specific task defaults.
+
+For interactive Codex sessions, `codex --profile yolo --no-alt-screen` plus `tp send --wait` is the current best-supported flow. Brand-new repos and worktrees can still stop at a Codex trust prompt before normal readiness begins. `tp` now verifies the tmux pane cwd before and immediately after agent launch and fails loudly if the shell or agent drifts out of the requested directory.
+
+`--here` is plain-mode only. It uses your current working directory as the session directory, records inferred git metadata such as repo root, current branch, and whether the checkout is a linked worktree, and can infer the session name from that directory when you omit `NAME`. If that inferred name already exists, `tp new` auto-suffixes it as `-1`, `-2`, and so on. `-j/--jump` attaches or switches to the new session immediately after creation.
 
 Concrete config-driven examples:
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ uv tool install tmux-pilot
 ## Quick Start
 
 ```bash
-# Spin up a session for a feature branch
-tp new auth-flow -c ~/repos/myapp -d "Implement OAuth2 login"
+# Start Codex in the current repo with the built-in `codex` profile
+tp new auth-flow --profile codex -c ~/repos/myapp
 
-# Launch Claude Code inside it
-tp send auth-flow "claude-code"
+# Bootstrap a task branch + worktree from a local repo, then launch Claude Code
+tp new oauth-fix --profile claude --repo ~/repos/myapp -d "Fix OAuth callback handling"
+
+# Bootstrap from GitHub if the repo is not cloned locally yet
+tp new pi-smoke --profile pi --repo badlogic/pi-mono
 
 # Check on all your sessions
 tp ls
@@ -73,7 +76,57 @@ tp new NAME                    # bare session
 tp new NAME -c ~/repos/myapp   # set working directory + @repo
 tp new NAME -d "description"   # set @desc metadata
 tp new NAME -c DIR -d DESC     # both
+
+# Launch a built-in agent profile in-place
+tp new NAME --profile codex -c ~/repos/myapp
+
+# Bootstrap a task branch + worktree from a repo, then launch the profile
+tp new NAME --profile claude --repo ~/repos/myapp
+
+# `--repo` accepts a local path, GitHub owner/repo, or GitHub URL
+tp new NAME --profile pi --repo badlogic/pi-mono
+tp new NAME --profile pi --repo https://github.com/badlogic/pi-mono.git
+
+# Override branch/base selection when needed
+tp new NAME --profile codex --repo ~/repos/myapp --branch chore/name-cleanup
+tp new NAME --profile codex --repo ~/repos/myapp --base-ref origin/release/1.2
 ```
+
+When `--repo` is used, `tp new` now handles the full task bootstrap flow:
+
+- resolves or clones the repo
+- derives a task branch from the session name (or `--issue`)
+- creates a git worktree under the configured worktree base
+- starts the requested agent inside that worktree
+
+Built-in launch profiles:
+
+- `codex`: `codex --profile yolo`
+- `claude`: `claude --permission-mode bypassPermissions`
+- `pi`: `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+
+Recommended profile config lives at `~/.config/tmux-pilot/profiles.toml`:
+
+```toml
+[default]
+extends = "codex"
+worktree_base = "~/worktrees"
+clone_base = "~/repos"
+
+[profiles.claude]
+worktree_base = "~/worktrees"
+
+[profiles.pi]
+branch_prefix = "task"
+
+[profiles.myapp]
+extends = "codex"
+repo = "~/repos/myapp"
+branch_prefix = "feat"
+base_ref = "origin/main"
+```
+
+`extends` can target another configured profile or one of the built-in profiles above. Config values override the inherited profile, so you can keep reusable agent defaults separate from repo-specific task defaults.
 
 ### `tp peek` — View scrollback without attaching
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,11 @@
 This project keeps the docs split by Diataxis:
 
 - [Tutorials](./tutorials/drive-a-kept-alive-agent-session.md): guided, end-to-end learning.
+- [How-to guides](./how-to/create-sessions.md): choose between bare sessions, in-place profile launches, and worktree-backed task sessions.
 - [How-to guides](./how-to/wait-for-interactive-agents.md): solve a specific operational task.
 - [How-to guides](./how-to/start-task-sessions-with-profiles-and-worktrees.md): copy-paste examples for Codex, Claude Code, Pi, and task/worktree bootstrap from `tp new`.
 - [Explanation](./explanation/file-backed-agent-state.md): why the agent-state model works the way it does.
 - [Reference](./reference/agent-state.md): commands, states, transcript sources, and current behavior.
+- [Reference](./reference/session-creation.md): exact `tp new` mode-selection and option semantics.
 
 If you are new to `tp`, start with the tutorial. If you already use `tp` and need reliable follow-up sends to a busy agent, go straight to the how-to guide.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This project keeps the docs split by Diataxis:
 
 - [Tutorials](./tutorials/drive-a-kept-alive-agent-session.md): guided, end-to-end learning.
 - [How-to guides](./how-to/wait-for-interactive-agents.md): solve a specific operational task.
-- [How-to guides](./how-to/start-task-sessions-with-profiles-and-worktrees.md): bootstrap task branches, worktrees, and agent profiles from `tp new`.
+- [How-to guides](./how-to/start-task-sessions-with-profiles-and-worktrees.md): copy-paste examples for Codex, Claude Code, Pi, and task/worktree bootstrap from `tp new`.
 - [Explanation](./explanation/file-backed-agent-state.md): why the agent-state model works the way it does.
 - [Reference](./reference/agent-state.md): commands, states, transcript sources, and current behavior.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This project keeps the docs split by Diataxis:
 
 - [Tutorials](./tutorials/drive-a-kept-alive-agent-session.md): guided, end-to-end learning.
 - [How-to guides](./how-to/wait-for-interactive-agents.md): solve a specific operational task.
+- [How-to guides](./how-to/start-task-sessions-with-profiles-and-worktrees.md): bootstrap task branches, worktrees, and agent profiles from `tp new`.
 - [Explanation](./explanation/file-backed-agent-state.md): why the agent-state model works the way it does.
 - [Reference](./reference/agent-state.md): commands, states, transcript sources, and current behavior.
 

--- a/docs/explanation/file-backed-agent-state.md
+++ b/docs/explanation/file-backed-agent-state.md
@@ -39,3 +39,12 @@ This is the key merge:
 ## Fallback behavior
 
 For agents without a file-backed plugin, `tp` falls back to pane heuristics only. That keeps `tp` broadly usable while allowing higher-confidence behavior for supported interactive agents.
+
+## Operational conclusions
+
+Real-world use has clarified a few product boundaries:
+
+- `tp new --agent "codex --profile yolo --no-alt-screen"` plus `tp send --wait` is a meaningful improvement over the older one-shot send model.
+- Codex trust prompts are normal in brand-new repos and worktrees. They should be treated as an explicit product state, not hand-waved away as a transient glitch.
+- Session metadata alone is not enough to trust launch correctness. `tp` must verify the live pane cwd before and immediately after agent launch, because a shell or agent can drift away from the requested directory while metadata still looks correct.
+- Low-level setup commands and first-class worktree-aware creation are still missing features. When users need them, that should be recorded as a blocker or roadmap item rather than normalized as a permanent shell-script workaround.

--- a/docs/how-to/create-sessions.md
+++ b/docs/how-to/create-sessions.md
@@ -1,0 +1,97 @@
+# Create Sessions
+
+Use this guide when you want to understand which `tp new` flags create a plain tmux session, which ones launch a profile in place, and which ones create a profile-backed worktree session.
+
+## Create a plain tmux session
+
+```bash
+tp new scratch
+tp new scratch -c ~/repos/myapp
+tp new scratch --here
+tp new --here
+tp new -c ~/repos/myapp
+```
+
+This creates a detached tmux session only. No git worktree is created.
+
+`--here` is plain-mode sugar for “use the directory I am currently in”, and it also records inferred git metadata from that checkout.
+
+When you omit `NAME` in plain mode and provide `--here` or `--directory`, `tp` infers the session name from the repo or worktree root. That means a linked worktree such as `~/worktrees/dismech-prev-1` defaults to a session name like `dismech-prev-1`.
+
+If that inferred name already exists, `tp` auto-uniqueifies it as `dismech-prev-1-1`, `dismech-prev-1-2`, and so on. Explicitly provided names still fail on collision.
+
+## Create a plain tmux session and launch an agent
+
+```bash
+tp new foo-codex-test --agent codex
+tp new foo-codex-test --agent codex --prompt "1+3"
+tp new foo-codex-test -c ~/worktrees/myrepo --agent "codex --profile yolo --no-alt-screen"
+```
+
+Here, `--agent` is the command to launch inside the new tmux session.
+
+Common values:
+
+- `claude`
+- `claude-code`
+- `codex`
+
+For kept-alive Codex sessions, `codex --profile yolo --no-alt-screen` plus `tp send --wait` is the most reliable current flow.
+
+Brand-new repos and worktrees can still stop at a Codex trust prompt before the normal input prompt appears. That trust prompt is expected. `tp send --wait` helps after startup, but trust bootstrap is not yet a first-class workflow.
+
+When you create a session with `-c DIR`, `tp` now verifies that the tmux pane is actually in `DIR` before it launches the agent and immediately after launch. If the shell or the agent drifts to another directory, `tp` fails loudly instead of silently launching in the wrong tree.
+
+## Jump into the session immediately
+
+```bash
+tp new scratch --here --jump
+tp new review-771 --profile dismech --issue 771 --jump
+```
+
+`-j`/`--jump` attaches or switches to the new session as soon as it has been created.
+
+## Launch a profile in an existing checkout
+
+```bash
+tp new docs-pass --profile codex -c ~/repos/tmux-pilot
+tp new review-pass --profile claude -c ~/repos/myapp
+```
+
+This uses the selected profile's command in the existing checkout passed by `--directory`. No new worktree is created.
+
+## Create a profile-backed worktree session
+
+```bash
+tp new review-771 --profile dismech --issue 771
+tp new auth-fix --profile default
+```
+
+Profile mode creates a worktree from the configured repository, records repo and branch metadata, and can launch the configured agent automatically.
+
+## Override the profile's agent
+
+```bash
+tp new review-771 --profile default --agent codex --prompt "Write tests first"
+```
+
+Use `--profile` when you want worktree/profile behavior and also want to override the profile's default agent command.
+
+## `--directory` vs `--repo` vs `--here`
+
+- `--directory`: use an existing checkout as the working directory. In plain mode this creates a bare session there. With `--profile`, it launches the selected profile in place.
+- `--repo`: profile mode bootstrap source. `tp` resolves or clones the repo, creates a task worktree, and launches the selected profile there.
+- `--here`: plain mode only. It uses the current directory, infers repo/branch/worktree metadata, and can infer the session name when `NAME` is omitted.
+
+## Where agent flags belong
+
+Use `--agent` for the executable name or command. Put stable flags in `profiles.toml` as `agent_args`.
+
+Example:
+
+```toml
+[default]
+repo = "~/repos/myapp"
+agent = "codex"
+agent_args = "--profile yolo --no-alt-screen"
+```

--- a/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
+++ b/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
@@ -1,0 +1,65 @@
+# Start Task Sessions With Profiles And Worktrees
+
+Use `tp new` when you want one command to prepare a task workspace and launch an agent inside it.
+
+## Start In Place
+
+Launch an agent profile directly in an existing directory:
+
+```bash
+tp new docs-pass --profile codex -c ~/repos/tmux-pilot
+tp new review-pass --profile claude -c ~/repos/myapp
+tp new pi-local --profile pi -c ~/repos/pi-mono
+```
+
+Built-in profiles:
+
+- `codex` -> `codex --profile yolo`
+- `claude` -> `claude --permission-mode bypassPermissions`
+- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+
+## Bootstrap A Task Repo
+
+Point `--repo` at either a local checkout or a GitHub repository:
+
+```bash
+tp new auth-fix --profile codex --repo ~/repos/myapp
+tp new issue-771 --profile claude --repo ~/repos/myapp --issue 771
+tp new pi-smoke --profile pi --repo badlogic/pi-mono
+```
+
+That flow:
+
+1. Resolves or clones the repo.
+2. Derives a branch from the session name or issue number.
+3. Creates a worktree under the configured worktree base.
+4. Starts the selected agent in that worktree.
+
+Override the branch or base ref when needed:
+
+```bash
+tp new cleanup --profile codex --repo ~/repos/myapp --branch chore/cleanup
+tp new backport --profile codex --repo ~/repos/myapp --base-ref origin/release/1.2
+```
+
+## Configure Reusable Profiles
+
+Create `~/.config/tmux-pilot/profiles.toml`:
+
+```toml
+[default]
+extends = "codex"
+worktree_base = "~/worktrees"
+clone_base = "~/repos"
+
+[profiles.pi]
+branch_prefix = "task"
+
+[profiles.myapp]
+extends = "claude"
+repo = "~/repos/myapp"
+branch_prefix = "feat"
+base_ref = "origin/main"
+```
+
+`extends` can reference either another configured profile or a built-in profile.

--- a/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
+++ b/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
@@ -4,11 +4,16 @@ Use `tp new` when you want one command to prepare a task workspace and launch an
 
 ## Start In Place
 
-Launch an agent profile directly in an existing directory:
+Launch an agent profile directly in an existing directory. These examples show the exact agent command that `tp` starts inside tmux:
 
 ```bash
+# Runs: codex --profile yolo
 tp new docs-pass --profile codex -c ~/repos/tmux-pilot
+
+# Runs: claude --permission-mode bypassPermissions
 tp new review-pass --profile claude -c ~/repos/myapp
+
+# Runs: pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
 tp new pi-local --profile pi -c ~/repos/pi-mono
 ```
 
@@ -20,20 +25,40 @@ Built-in profiles:
 
 ## Bootstrap A Task Repo
 
-Point `--repo` at either a local checkout or a GitHub repository:
+Point `--repo` at either a local checkout or a GitHub repository.
+
+Example: bootstrap from a local checkout:
 
 ```bash
 tp new auth-fix --profile codex --repo ~/repos/myapp
+```
+
+With the default settings, that command:
+
+1. Resolves or clones the repo.
+2. Derives branch `feat/auth-fix`.
+3. Creates worktree `~/worktrees/myapp-auth-fix`.
+4. Starts `codex --profile yolo` in that worktree.
+
+Issue-driven example:
+
+```bash
 tp new issue-771 --profile claude --repo ~/repos/myapp --issue 771
+```
+
+That command derives branch `fix/771-issue-771`, fetches the issue title into `@desc`, and launches `claude --permission-mode bypassPermissions` in the new worktree.
+
+GitHub bootstrap example:
+
+```bash
 tp new pi-smoke --profile pi --repo badlogic/pi-mono
 ```
 
-That flow:
+If `~/repos/pi-mono` does not exist yet, `tp` clones it first. Then it creates worktree `~/worktrees/pi-mono-pi-smoke`, derives branch `feat/pi-smoke`, and launches:
 
-1. Resolves or clones the repo.
-2. Derives a branch from the session name or issue number.
-3. Creates a worktree under the configured worktree base.
-4. Starts the selected agent in that worktree.
+```bash
+pi --session-dir ~/worktrees/pi-mono-pi-smoke/.tmux-pilot/pi/sessions
+```
 
 Override the branch or base ref when needed:
 
@@ -53,13 +78,27 @@ worktree_base = "~/worktrees"
 clone_base = "~/repos"
 
 [profiles.pi]
+extends = "pi"
 branch_prefix = "task"
 
 [profiles.myapp]
-extends = "claude"
+extends = "codex"
 repo = "~/repos/myapp"
 branch_prefix = "feat"
 base_ref = "origin/main"
 ```
 
 `extends` can reference either another configured profile or a built-in profile.
+
+Concrete config-driven examples:
+
+```bash
+# Uses `[default]`, so it launches Codex even without `--profile`.
+tp new rename-types -c ~/repos/myapp
+
+# Uses repo/base_ref from `[profiles.myapp]`, so `--repo` is optional.
+tp new api-cleanup --profile myapp
+
+# Uses the customized Pi profile, so the branch is `task/pi-smoke`.
+tp new pi-smoke --profile pi --repo badlogic/pi-mono
+```

--- a/docs/reference/agent-state.md
+++ b/docs/reference/agent-state.md
@@ -32,6 +32,12 @@ Readiness is slightly stricter than state:
 - `completed` is ready only after the prompt is visibly back
 - `running` is not ready
 
+States that are not first-class yet:
+
+- trust prompt
+- shell idle
+- exited
+
 ## Transcript sources
 
 ### Codex
@@ -86,3 +92,8 @@ If no session file is available yet, `tp` falls back to the visible Pi footer an
 ### Generic agents
 
 Generic sessions do not have file-backed state. `tp` uses pane heuristics only.
+
+## Known gaps
+
+- Codex trust prompts in brand-new repos and worktrees are expected, but `tp` does not yet surface a dedicated `trust-prompt` state.
+- `tp send --wait` starts helping once the interactive agent has reached a sendable prompt. It does not auto-accept trust bootstrap.

--- a/docs/reference/agent-state.md
+++ b/docs/reference/agent-state.md
@@ -48,6 +48,13 @@ Readiness is slightly stricter than state:
 
 `CLAUDE_PROJECTS_DIR` is primarily useful for tests or nonstandard layouts. Claude Code itself normally writes under `~/.claude/projects`.
 
+### Pi
+
+- default transcript root: `~/.pi/agent/sessions/--<cwd>--`
+- configurable root: `PI_CODING_AGENT_DIR/sessions/--<cwd>--`
+- built-in `tp` profile root: `{worktree}/.tmux-pilot/pi/sessions`
+- session matching: tmux pane working directory to session header `cwd`
+
 ## Agent-specific behavior
 
 ### `codex`
@@ -63,6 +70,18 @@ State comes from the latest meaningful Claude transcript entry:
 - assistant message with plain text completion => `completed`
 
 `tp` then confirms that the Claude prompt has returned in the pane before it marks the session ready.
+
+### `pi`
+
+Pi uses a mix of pane heuristics and session-file state:
+
+- assistant `stopReason=toolUse` => `running`
+- user, tool result, or bash execution entries => `running`
+- assistant `stopReason=stop` => `completed`
+- assistant `stopReason=aborted` => `interrupted`
+- assistant `stopReason=error` => `error`
+
+If no session file is available yet, `tp` falls back to the visible Pi footer and command palette prompt markers in the pane.
 
 ### Generic agents
 

--- a/docs/reference/session-creation.md
+++ b/docs/reference/session-creation.md
@@ -1,0 +1,79 @@
+# Session Creation Reference
+
+This page documents how `tp new` chooses between plain mode and profile mode.
+
+## Plain Mode
+
+Plain mode creates a detached tmux session. It may also launch an agent command directly inside that session.
+
+Triggers:
+
+- no profile settings apply
+- explicit `--here`
+- explicit `--agent` without `--profile`, `--issue`, `--repo`, or `--no-agent`
+- explicit `--directory` when profile/worktree bootstrap mode is not otherwise selected
+
+Behavior:
+
+- creates a tmux session
+- optionally sets `@desc`
+- optionally launches the `--agent` command
+- optionally sends `--prompt` after the agent starts
+- verifies the pane cwd when plain mode was given `--directory` or `--here`
+- when `--here` is used, records inferred repo/branch/worktree metadata from the current checkout
+- when `NAME` is omitted with `--directory` or `--here`, infers the session name from the repo/worktree root
+- when an inferred name collides, auto-uniqueifies it with `-1`, `-2`, and so on
+
+In plain mode, `--prompt` requires `--agent`.
+
+## Profile Mode
+
+Profile mode creates a git worktree-backed tmux session using `~/.config/tmux-pilot/profiles.toml`.
+
+Triggers:
+
+- `--profile`
+- `--issue`
+- `--repo`
+- `--no-agent`
+- `--branch`
+- `--base-ref`
+- an existing `[default]` profile when plain mode is not forced
+
+Behavior:
+
+- resolves repo, worktree base, agent, `agent_args`, and branch prefix from the selected profile
+- uses `--directory` for an in-place launch when provided
+- otherwise creates a task worktree from the configured repo and base ref
+- records repo and branch metadata
+- optionally launches the resolved agent
+- optionally sends `--prompt`
+- verifies that the pane cwd stays on the requested directory or created worktree when launching the agent
+
+## `profiles.toml` Fields
+
+Supported fields:
+
+- `repo`: local repository path
+- `agent`: agent command to launch
+- `agent_args`: stable flags appended to `agent`
+- `worktree_base`: parent directory for created worktrees
+- `branch_prefix`: branch prefix such as `feat` or `fix`
+
+## Option Semantics
+
+- `--agent`: command to launch in the session, such as `claude`, `claude-code`, or `codex`
+- `--prompt`: initial text to send after the agent launches
+- `NAME`: optional when `--directory` or `--here` is present
+- `--directory`: existing working directory; plain mode creates a bare session there, while profile mode launches the selected profile in place
+- `--here`: plain mode shortcut for “use the current working directory and infer git metadata”
+- `--repo`: profile mode bootstrap source or repo override
+- `--no-agent`: profile mode only; create the worktree/session but skip launching the configured agent
+- `--jump`: attach or switch to the new session immediately after creation
+
+## Known Limitations
+
+- Brand-new Codex repos and worktrees may stop at a trust prompt before the normal input prompt appears. This is expected behavior, not a mysterious readiness failure.
+- `tp` does not yet expose first-class `trust-prompt`, `shell-idle`, or `exited` readiness states.
+- `tp new` does not yet provide a built-in `--setup-cmd` or a first-class `--worktree-from ... --branch ...` workflow.
+- Those missing setup/worktree orchestration features should be treated as product gaps or blockers, not as places to normalize bespoke shell-script workarounds.

--- a/src/tmux_pilot/agent_sessions.py
+++ b/src/tmux_pilot/agent_sessions.py
@@ -33,6 +33,12 @@ def claude_projects_root() -> Path:
     return Path(os.environ.get("CLAUDE_PROJECTS_DIR", "~/.claude/projects")).expanduser()
 
 
+def pi_sessions_root() -> Path:
+    """Return the Pi sessions directory."""
+    agent_dir = Path(os.environ.get("PI_CODING_AGENT_DIR", "~/.pi/agent")).expanduser()
+    return agent_dir / "sessions"
+
+
 def _normalize_cwd(cwd: str) -> str:
     if not cwd:
         return ""
@@ -136,6 +142,47 @@ def find_claude_transcript_for_cwd(
     return None
 
 
+def _pi_encoded_session_dir(cwd: str) -> str:
+    normalized = _normalize_cwd(cwd)
+    safe = normalized.lstrip("/\\").replace("/", "-").replace("\\", "-").replace(":", "-")
+    return f"--{safe}--"
+
+
+def _pi_candidate_roots(cwd: str, *, root: Path | None = None) -> list[Path]:
+    if root is not None:
+        return [root]
+
+    target = _normalize_cwd(cwd)
+    if not target:
+        return [pi_sessions_root()]
+
+    worktree_root = Path(target) / ".tmux-pilot" / "pi" / "sessions"
+    default_root = pi_sessions_root() / _pi_encoded_session_dir(target)
+    roots = []
+    if worktree_root.exists():
+        roots.append(worktree_root)
+    roots.append(default_root)
+    return roots
+
+
+def find_pi_transcript_for_cwd(
+    cwd: str,
+    *,
+    root: Path | None = None,
+    limit: int = _TRANSCRIPT_SCAN_LIMIT,
+) -> Path | None:
+    """Return the most recent Pi session file whose cwd matches *cwd*."""
+    target = _normalize_cwd(cwd)
+    if not target:
+        return None
+
+    for sessions_root in _pi_candidate_roots(target, root=root):
+        for path in _recent_jsonl_files(sessions_root, limit=limit):
+            if transcript_cwd(path) == target:
+                return path
+    return None
+
+
 def find_transcript_for_cwd(
     agent_type: str,
     cwd: str,
@@ -147,6 +194,8 @@ def find_transcript_for_cwd(
         return find_codex_transcript_for_cwd(cwd, limit=limit)
     if agent_type == "claude-code":
         return find_claude_transcript_for_cwd(cwd, limit=limit)
+    if agent_type == "pi":
+        return find_pi_transcript_for_cwd(cwd, limit=limit)
     return None
 
 
@@ -227,7 +276,7 @@ def _record_timestamp(record: dict) -> str:
 
 
 def _record_turn_id(record: dict) -> str:
-    for key in ("uuid", "turn_id", "sessionId"):
+    for key in ("id", "uuid", "turn_id", "sessionId"):
         value = record.get(key)
         if isinstance(value, str):
             return value
@@ -286,6 +335,50 @@ def read_claude_transcript_state(path: Path) -> TranscriptState | None:
     return None
 
 
+def _pi_message_state(record: dict) -> str | None:
+    if record.get("type") != "message":
+        return None
+
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return None
+
+    role = message.get("role")
+    if role in {"user", "toolResult", "bashExecution"}:
+        return "running"
+    if role != "assistant":
+        return None
+
+    stop_reason = message.get("stopReason")
+    if stop_reason == "toolUse":
+        return "running"
+    if stop_reason == "aborted":
+        return "interrupted"
+    if stop_reason == "error":
+        return "error"
+    return "completed"
+
+
+def read_pi_transcript_state(path: Path) -> TranscriptState | None:
+    """Return the latest Pi lifecycle state from *path*."""
+    for line in _iter_lines_reverse(path):
+        record = _load_json_line(line)
+        if record is None:
+            continue
+
+        state = _pi_message_state(record)
+        if state is None:
+            continue
+
+        return TranscriptState(
+            path=path,
+            state=state,
+            timestamp=_record_timestamp(record),
+            turn_id=_record_turn_id(record),
+        )
+    return None
+
+
 def get_codex_transcript_state(
     cwd: str,
     *,
@@ -310,3 +403,16 @@ def get_claude_transcript_state(
     if path is None:
         return None
     return read_claude_transcript_state(path)
+
+
+def get_pi_transcript_state(
+    cwd: str,
+    *,
+    transcript_path: Path | None = None,
+    root: Path | None = None,
+) -> TranscriptState | None:
+    """Resolve and read the latest Pi session state for *cwd*."""
+    path = transcript_path or find_pi_transcript_for_cwd(cwd, root=root)
+    if path is None:
+        return None
+    return read_pi_transcript_state(path)

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -36,17 +36,20 @@ def cmd_new(args: argparse.Namespace) -> None:
             issue=args.issue,
             agent=args.agent,
             repo=args.repo,
+            branch=args.branch,
+            base_ref=args.base_ref,
             no_agent=args.no_agent,
             prompt=args.prompt,
         ):
-            if args.directory:
-                raise RuntimeError("--directory is not supported with profile-based sessions; use --repo")
             core.create_profile_session(
                 args.name,
                 profile_name=args.profile,
                 issue=args.issue,
                 agent=args.agent,
                 repo=args.repo,
+                directory=args.directory,
+                branch=args.branch,
+                base_ref=args.base_ref,
                 no_agent=args.no_agent,
                 prompt=args.prompt,
                 desc=args.desc,
@@ -259,11 +262,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_new.add_argument("name", help="Session name")
     p_new.add_argument("--profile", help="Named profile from ~/.config/tmux-pilot/profiles.toml")
     p_new.add_argument("--issue", type=int, help="GitHub issue number to derive metadata from")
-    p_new.add_argument("--agent", help="Override the profile's agent")
-    p_new.add_argument("--repo", help="Override the profile's repository")
+    p_new.add_argument("--agent", help="Override the profile's agent command")
+    p_new.add_argument("--repo", help="Bootstrap from a local repo path or GitHub owner/repo[/url]")
+    p_new.add_argument("--branch", help="Override the derived task branch name")
+    p_new.add_argument("--base-ref", help="Override the base ref used when creating a task worktree")
     p_new.add_argument("--no-agent", action="store_true", help="Create the session without launching an agent")
     p_new.add_argument("--prompt", help="Initial prompt to send to the agent after startup")
-    p_new.add_argument("-c", "--directory", help="Working directory")
+    p_new.add_argument("-c", "--directory", help="Working directory for a non-bootstrap session")
     p_new.add_argument("-d", "--desc", help="Description")
 
     # peek

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 
 from pathlib import Path
 
 from . import core, display, hooks
+
+
+_NEW_DESCRIPTION = """Create a tmux session.
+
+Plain mode creates a detached tmux session with an optional working directory and description.
+It can also launch an agent command directly in that session with --agent and optionally send an
+initial prompt with --prompt. Use --here to root the session in your current folder and copy repo,
+branch, and worktree metadata from that checkout.
+
+Profile mode launches a configured profile in-place with --directory or bootstraps a task worktree
+with --repo. It can derive branches, create worktrees, launch the selected agent command, and send
+an initial prompt once the agent becomes ready.
+"""
+
+
+_NEW_EPILOG = """Examples:
+  tp new scratch -c ~/repos/myapp
+  tp new -c ~/repos/myapp
+  tp new --here
+  tp new scratch --here --jump
+  tp new foo-codex-test --agent codex --prompt "1+3"
+  tp new review-771 --profile dismech --issue 771
+  tp new codex-fix --profile default --agent codex --prompt "Write tests for the parser"
+  tp new cleanup --profile codex --repo ~/repos/myapp --branch chore/cleanup
+
+Agent values are shell commands, not fixed enums. Use the command you would launch inside tmux.
+Common values: claude, claude-code, codex, pi
+"""
 
 
 def cmd_ls(args: argparse.Namespace) -> None:
@@ -26,9 +55,35 @@ def cmd_ls(args: argparse.Namespace) -> None:
 
 
 def cmd_new(args: argparse.Namespace) -> None:
-    if core.session_exists(args.name):
-        print(f"Session '{args.name}' already exists.", file=sys.stderr)
-        sys.exit(1)
+    directory = args.directory
+    used_here = False
+    if args.here:
+        if args.directory:
+            print("--here cannot be combined with --directory", file=sys.stderr)
+            sys.exit(1)
+        directory = os.getcwd()
+        used_here = True
+
+    name = args.name
+    inferred_name = False
+    if not name:
+        if directory:
+            try:
+                name = core.infer_session_name_for_directory(directory)
+                inferred_name = True
+            except RuntimeError as e:
+                print(str(e), file=sys.stderr)
+                sys.exit(1)
+        else:
+            print("Session name is required unless --directory or --here is provided.", file=sys.stderr)
+            sys.exit(1)
+
+    if core.session_exists(name):
+        if inferred_name:
+            name = core.uniqueify_session_name(name)
+        else:
+            print(f"Session '{name}' already exists.", file=sys.stderr)
+            sys.exit(1)
 
     try:
         if core.should_use_profile_mode(
@@ -40,14 +95,17 @@ def cmd_new(args: argparse.Namespace) -> None:
             base_ref=args.base_ref,
             no_agent=args.no_agent,
             prompt=args.prompt,
+            directory=directory,
         ):
+            if used_here:
+                raise RuntimeError("--here is plain-mode only; use --directory or --repo")
             core.create_profile_session(
-                args.name,
+                name,
                 profile_name=args.profile,
                 issue=args.issue,
                 agent=args.agent,
                 repo=args.repo,
-                directory=args.directory,
+                directory=directory,
                 branch=args.branch,
                 base_ref=args.base_ref,
                 no_agent=args.no_agent,
@@ -55,12 +113,29 @@ def cmd_new(args: argparse.Namespace) -> None:
                 desc=args.desc,
             )
         else:
-            core.new_session(args.name, directory=args.directory, desc=args.desc)
+            if args.prompt and not args.agent:
+                raise RuntimeError("--prompt requires --agent in plain mode; use --profile to send a prompt via a profile agent")
+            core.new_session(name, directory=directory, desc=args.desc)
+            if used_here and directory:
+                core.apply_directory_metadata(name, directory)
+            if args.agent:
+                core.launch_agent_session(
+                    name,
+                    args.agent,
+                    prompt=args.prompt,
+                    expected_cwd=directory,
+                )
     except RuntimeError as e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
 
-    print(f"Created session '{args.name}'")
+    print(f"Created session '{name}'")
+    if args.jump:
+        try:
+            core.jump_session(name)
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
 
 
 def cmd_peek(args: argparse.Namespace) -> None:
@@ -258,18 +333,30 @@ def build_parser() -> argparse.ArgumentParser:
     p_ls.add_argument("--process", help="Filter by process (e.g. claude-code, python)")
 
     # new
-    p_new = sub.add_parser("new", help="Create a new session")
-    p_new.add_argument("name", help="Session name")
+    p_new = sub.add_parser(
+        "new",
+        help="Create a bare session or a profile-backed task session",
+        description=_NEW_DESCRIPTION,
+        epilog=_NEW_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_new.add_argument(
+        "name",
+        nargs="?",
+        help="Session name; optional with --directory or --here, where it defaults to the directory or worktree name",
+    )
     p_new.add_argument("--profile", help="Named profile from ~/.config/tmux-pilot/profiles.toml")
     p_new.add_argument("--issue", type=int, help="GitHub issue number to derive metadata from")
-    p_new.add_argument("--agent", help="Override the profile's agent command")
+    p_new.add_argument("--agent", help="Override the profile's agent command or plain-mode launch command")
     p_new.add_argument("--repo", help="Bootstrap from a local repo path or GitHub owner/repo[/url]")
+    p_new.add_argument("-c", "--directory", help="Working directory for a non-bootstrap session or in-place profile launch")
     p_new.add_argument("--branch", help="Override the derived task branch name")
     p_new.add_argument("--base-ref", help="Override the base ref used when creating a task worktree")
     p_new.add_argument("--no-agent", action="store_true", help="Create the session without launching an agent")
     p_new.add_argument("--prompt", help="Initial prompt to send to the agent after startup")
-    p_new.add_argument("-c", "--directory", help="Working directory for a non-bootstrap session")
+    p_new.add_argument("--here", action="store_true", help="Plain mode only: use the current directory and infer git metadata from it")
     p_new.add_argument("-d", "--desc", help="Description")
+    p_new.add_argument("-j", "--jump", action="store_true", help="Attach or switch to the new session immediately after creating it")
 
     # peek
     p_peek = sub.add_parser("peek", help="Show last N lines of scrollback")

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -897,8 +897,6 @@ def create_profile_session(
     if (branch or base_ref) and not repo_source:
         raise RuntimeError("Branch/base-ref options require a git repo; pass --repo or run tp from a git checkout")
 
-    issue_title = _fetch_issue_title(_resolve_repo_source(repo_source, clone_base=profile.clone_base), issue) if issue is not None and repo_source else ""
-
     workspace: dict[str, str] = {}
     working_dir = ""
     if repo_source:
@@ -913,6 +911,12 @@ def create_profile_session(
         working_dir = workspace["worktree"]
     else:
         working_dir = str(Path(directory or os.getcwd()).expanduser().resolve())
+
+    issue_title = ""
+    if issue is not None:
+        issue_repo = workspace.get("repo", _git_root(working_dir))
+        if issue_repo:
+            issue_title = _fetch_issue_title(issue_repo, issue)
 
     session_desc = _initial_prompt_desc(desc, issue_title)
     rendered_command = ""

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import time
@@ -22,6 +23,7 @@ METADATA_KEYS = ("repo", "task", "desc", "status", "origin", "branch", "needs", 
 PROCESS_ALIASES: dict[str, str] = {
     "claude": "claude-code",
     "codex": "codex",
+    "pi": "pi",
     "python": "python",
     "zsh": "zsh",
     "bash": "bash",
@@ -38,8 +40,28 @@ NODE_DISAMBIGUATION: dict[str, str] = {
 
 _VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 PROFILE_CONFIG_PATH = Path.home() / ".config" / "tmux-pilot" / "profiles.toml"
+_DEFAULT_CLONE_BASE = "~/repos"
 _DEFAULT_WORKTREE_BASE = "~/worktrees"
 _SEND_KEYS_SETTLE_DELAY = 0.1
+_PI_SESSION_DIR_TEMPLATE = "{worktree}/.tmux-pilot/pi/sessions"
+_BUILTIN_PROFILE_DEFS: dict[str, dict[str, object]] = {
+    "codex": {
+        "command": ["codex", "--profile", "yolo"],
+        "prompt_wait_timeout": 10.0,
+    },
+    "claude": {
+        "command": ["claude", "--permission-mode", "bypassPermissions"],
+        "prompt_wait_timeout": 10.0,
+    },
+    "pi": {
+        "command": ["pi", "--session-dir", _PI_SESSION_DIR_TEMPLATE],
+        "prompt_wait_timeout": 5.0,
+    },
+}
+_GITHUB_REPO_RE = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/|github\.com/)?"
+    r"(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$"
+)
 
 
 @dataclass
@@ -47,11 +69,24 @@ class SessionProfile:
     """Resolved project profile for `tp new --profile`."""
 
     name: str
+    extends: str = ""
     repo: str = ""
     agent: str = ""
     agent_args: str = ""
+    command: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+    clone_base: str = _DEFAULT_CLONE_BASE
     worktree_base: str = _DEFAULT_WORKTREE_BASE
     branch_prefix: str = ""
+    base_ref: str = ""
+    prompt_wait_timeout: float = 10.0
+
+    @property
+    def command_parts(self) -> tuple[str, ...]:
+        if self.command:
+            return self.command
+        parts = [self.agent.strip(), *shlex.split(self.agent_args)]
+        return tuple(part for part in parts if part)
 
 
 def _run(
@@ -88,17 +123,69 @@ def tmux_running() -> bool:
     return result.returncode == 0
 
 
-def _detect_process(pane_cmd: str, session_name: str = "") -> str:
+def _child_pids(pid: str) -> list[str]:
+    """Return child process IDs for *pid*."""
+    if not pid:
+        return []
+    result = _run(["pgrep", "-P", pid], check=False, timeout=3)
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _raw_process_command_line(pid: str = "") -> str:
+    if not pid:
+        return ""
+    result = _run(["ps", "-o", "command=", "-p", pid], check=False, timeout=3)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _process_command_line(pane_pid: str = "") -> str:
+    """Return the foreground-ish command line for a pane."""
+    current_pid = pane_pid
+    command_line = _raw_process_command_line(current_pid)
+
+    while command_line:
+        base = Path(command_line.split()[0]).name.lower()
+        if base not in {"zsh", "bash", "fish", "sh"}:
+            return command_line
+
+        children = _child_pids(current_pid)
+        if not children:
+            return command_line
+        current_pid = children[-1]
+        command_line = _raw_process_command_line(current_pid)
+
+    return ""
+
+
+def _detect_process(pane_cmd: str, session_name: str = "", pane_pid: str = "") -> str:
     """Map a pane_current_command to a friendly name."""
     cmd = pane_cmd.strip()
     # Claude Code reports its version number as the command (e.g. "2.1.76")
     if _VERSION_RE.match(cmd):
         return "claude-code"
     cmd_lower = cmd.lower()
+    child_cmd = _process_command_line(pane_pid).lower()
+    if cmd_lower in {"zsh", "bash", "fish", "sh"} and child_cmd and child_cmd != cmd_lower:
+        for key, alias in PROCESS_ALIASES.items():
+            if key in child_cmd:
+                return alias
+        for key, alias in NODE_DISAMBIGUATION.items():
+            if key in child_cmd:
+                return alias
     # "node" is ambiguous — both Claude Code and Codex run as node.
     # For tp ls (fast path): use session name / @task hints.
     # For tp status (slow path): inspect child process command line.
     if cmd_lower == "node":
+        for key, alias in PROCESS_ALIASES.items():
+            if key in child_cmd:
+                return alias
+        for key, alias in NODE_DISAMBIGUATION.items():
+            if key in child_cmd:
+                return alias
         name_lower = session_name.lower()
         for key, alias in NODE_DISAMBIGUATION.items():
             if key in name_lower:
@@ -119,6 +206,7 @@ class SessionInfo:
     name: str
     process: str = "unknown"
     working_dir: str = ""
+    pid: str = ""
     metadata: dict[str, str] = field(default_factory=dict)
     agent_state: str = ""
 
@@ -146,26 +234,27 @@ class SessionInfo:
 
 
 _META_FMT = "\t".join(f"#{{@{k}}}" for k in METADATA_KEYS)
-_SESSION_FMT = f"#{{session_name}}\t#{{pane_current_command}}\t#{{pane_current_path}}\t{_META_FMT}"
+_SESSION_FMT = f"#{{session_name}}\t#{{pane_current_command}}\t#{{pane_current_path}}\t#{{pane_pid}}\t{_META_FMT}"
 
 
 def _parse_session_line(line: str) -> SessionInfo | None:
     """Parse a single tab-separated tmux format line into a SessionInfo."""
     parts = line.split("\t")
-    if len(parts) < 3:
+    if len(parts) < 4:
         return None
 
-    name, pane_cmd, pane_path = parts[0], parts[1], parts[2]
+    name, pane_cmd, pane_path, pane_pid = parts[0], parts[1], parts[2], parts[3]
     meta = {}
     for i, key in enumerate(METADATA_KEYS):
-        val = parts[3 + i] if (3 + i) < len(parts) else ""
+        val = parts[4 + i] if (4 + i) < len(parts) else ""
         if val:
             meta[key] = val
 
     return SessionInfo(
         name=name,
-        process=_detect_process(pane_cmd, name),
+        process=_detect_process(pane_cmd, name, pane_pid),
         working_dir=pane_path,
+        pid=pane_pid,
         metadata=meta,
     )
 
@@ -227,12 +316,15 @@ def new_session(
     *,
     directory: str | None = None,
     desc: str | None = None,
+    command: str | None = None,
 ) -> None:
     """Create a new detached tmux session with optional metadata."""
     cmd = ["tmux", "new-session", "-d", "-s", name]
     if directory:
         p = Path(directory).expanduser().resolve()
         cmd.extend(["-c", str(p)])
+    if command:
+        cmd.append(command)
     _run(cmd, check=True)
 
     if desc:
@@ -358,26 +450,108 @@ def _is_inside_tmux() -> bool:
     return "TMUX" in os.environ
 
 
-def load_profiles(path: Path | None = None) -> dict[str, SessionProfile]:
-    """Load configured session profiles from TOML."""
-    config_path = path or PROFILE_CONFIG_PATH
+def _load_profile_tables(config_path: Path) -> dict[str, dict[str, object]]:
     if not config_path.exists():
         return {}
 
     with config_path.open("rb") as handle:
         data = tomllib.load(handle)
 
+    if not isinstance(data, dict):
+        return {}
+
+    if isinstance(data.get("profiles"), dict):
+        source = data["profiles"]
+        tables = {name: values for name, values in source.items() if isinstance(values, dict)}
+        default_values = data.get("default")
+        if isinstance(default_values, dict) and "default" not in tables:
+            tables["default"] = default_values
+        return tables
+
+    return {name: values for name, values in data.items() if isinstance(values, dict)}
+
+
+def _resolve_profile_values(
+    name: str,
+    raw_profiles: dict[str, dict[str, object]],
+    *,
+    stack: tuple[str, ...] = (),
+) -> dict[str, object]:
+    if name in stack:
+        cycle = " -> ".join((*stack, name))
+        raise RuntimeError(f"Cyclic profile inheritance detected: {cycle}")
+    if name not in raw_profiles:
+        raise RuntimeError(f"Profile '{name}' not found in {PROFILE_CONFIG_PATH}")
+
+    values = dict(raw_profiles[name])
+    extends = values.get("extends")
+    if isinstance(extends, str) and extends:
+        base = _resolve_profile_values(extends, raw_profiles, stack=(*stack, name))
+        merged = dict(base)
+        merged.update(values)
+        values = merged
+    return values
+
+
+def _normalize_profile_command(values: dict[str, object]) -> tuple[str, ...]:
+    command = values.get("command")
+    if isinstance(command, str):
+        return tuple(shlex.split(command))
+    if isinstance(command, list):
+        return tuple(str(item) for item in command if str(item).strip())
+    if isinstance(command, tuple):
+        return tuple(str(item) for item in command if str(item).strip())
+
+    agent = str(values.get("agent", "")).strip()
+    agent_args = str(values.get("agent_args", "")).strip()
+    if not agent:
+        return ()
+    return tuple(part for part in (agent, *shlex.split(agent_args)) if part)
+
+
+def _normalize_profile_env(values: dict[str, object]) -> dict[str, str]:
+    env = values.get("env")
+    if not isinstance(env, dict):
+        return {}
+    return {str(key): str(value) for key, value in env.items()}
+
+
+def _command_to_agent_fields(command: tuple[str, ...]) -> tuple[str, str]:
+    if not command:
+        return "", ""
+    return command[0], " ".join(command[1:])
+
+
+def load_profiles(path: Path | None = None) -> dict[str, SessionProfile]:
+    """Load configured session profiles from TOML."""
+    config_path = path or PROFILE_CONFIG_PATH
+    raw_profiles = {name: dict(values) for name, values in _BUILTIN_PROFILE_DEFS.items()}
+    for name, values in _load_profile_tables(config_path).items():
+        if name in raw_profiles:
+            merged = dict(raw_profiles[name])
+            merged.update(values)
+            raw_profiles[name] = merged
+        else:
+            raw_profiles[name] = dict(values)
+
     profiles: dict[str, SessionProfile] = {}
-    for name, values in data.items():
-        if not isinstance(values, dict):
-            continue
+    for name in raw_profiles:
+        values = _resolve_profile_values(name, raw_profiles)
+        command = _normalize_profile_command(values)
+        agent, agent_args = _command_to_agent_fields(command)
         profiles[name] = SessionProfile(
             name=name,
+            extends=str(values.get("extends", "")),
             repo=str(values.get("repo", "")),
-            agent=str(values.get("agent", "")),
-            agent_args=str(values.get("agent_args", "")),
+            agent=agent,
+            agent_args=agent_args,
+            command=command,
+            env=_normalize_profile_env(values),
+            clone_base=str(values.get("clone_base", _DEFAULT_CLONE_BASE)),
             worktree_base=str(values.get("worktree_base", _DEFAULT_WORKTREE_BASE)),
             branch_prefix=str(values.get("branch_prefix", "")),
+            base_ref=str(values.get("base_ref", "")),
+            prompt_wait_timeout=float(values.get("prompt_wait_timeout", 10.0)),
         )
     return profiles
 
@@ -388,12 +562,14 @@ def should_use_profile_mode(
     issue: int | None = None,
     agent: str | None = None,
     repo: str | None = None,
+    branch: str | None = None,
+    base_ref: str | None = None,
     no_agent: bool = False,
     prompt: str | None = None,
     path: Path | None = None,
 ) -> bool:
     """Return True when `tp new` should use profile-backed creation."""
-    if profile_name or issue is not None or agent or repo or no_agent or prompt:
+    if profile_name or issue is not None or agent or repo or branch or base_ref or no_agent or prompt:
         return True
     return "default" in load_profiles(path)
 
@@ -408,7 +584,7 @@ def resolve_session_profile(
 ) -> SessionProfile | None:
     """Resolve a profile, merging explicit settings with `[default]`."""
     profiles = load_profiles(path)
-    if not profiles and not repo_override and not agent_override:
+    if not profile_name and "default" not in profiles and not repo_override and not agent_override:
         return None
 
     if profile_name and profile_name not in profiles:
@@ -417,18 +593,34 @@ def resolve_session_profile(
     selected_name = profile_name or ("default" if "default" in profiles else "")
     default = profiles.get("default", SessionProfile(name="default"))
     selected = profiles.get(selected_name, SessionProfile(name=selected_name or "default"))
+    command = selected.command_parts or default.command_parts
 
     branch_prefix = selected.branch_prefix or default.branch_prefix
     if not branch_prefix:
         branch_prefix = "fix" if issue is not None else "feat"
 
+    agent = selected.agent or default.agent
+    agent_args = selected.agent_args or default.agent_args
+    if agent_override:
+        override_command = tuple(shlex.split(agent_override))
+        if not override_command:
+            raise RuntimeError("Agent override produced an empty command")
+        command = override_command
+        agent, agent_args = _command_to_agent_fields(command)
+
     return SessionProfile(
         name=selected_name or "default",
+        extends=selected.extends or default.extends,
         repo=repo_override or selected.repo or default.repo,
-        agent=agent_override or selected.agent or default.agent,
-        agent_args=selected.agent_args or default.agent_args,
+        agent=agent,
+        agent_args=agent_args,
+        command=command,
+        env=dict(default.env) | dict(selected.env),
+        clone_base=selected.clone_base or default.clone_base or _DEFAULT_CLONE_BASE,
         worktree_base=selected.worktree_base or default.worktree_base or _DEFAULT_WORKTREE_BASE,
         branch_prefix=branch_prefix,
+        base_ref=selected.base_ref or default.base_ref,
+        prompt_wait_timeout=selected.prompt_wait_timeout or default.prompt_wait_timeout or 10.0,
     )
 
 
@@ -473,11 +665,202 @@ def _fetch_issue_title(repo_path: str, issue_number: int) -> str:
     return result.stdout.strip()
 
 
-def _launch_agent(session_name: str, agent: str, agent_args: str = "") -> None:
-    """Launch the configured agent inside the tmux session."""
-    command = " ".join(part for part in (agent.strip(), agent_args.strip()) if part)
-    if command:
-        send_keys(session_name, command)
+def _git_root(path: str) -> str:
+    """Return the git root for *path*, or an empty string when not in a repo."""
+    if not path:
+        return ""
+    result = _run(
+        ["git", "-C", path, "rev-parse", "--show-toplevel"],
+        check=False,
+        timeout=3,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _parse_github_repo(repo: str) -> tuple[str, str] | None:
+    match = _GITHUB_REPO_RE.match(repo.strip())
+    if not match:
+        return None
+    return match.group("owner"), match.group("repo")
+
+
+def _clone_github_repo(repo: str, *, clone_base: str) -> str:
+    parsed = _parse_github_repo(repo)
+    if parsed is None:
+        raise RuntimeError(f"Unsupported repository source '{repo}'")
+
+    owner, repo_name = parsed
+    clone_root = Path(clone_base).expanduser().resolve()
+    local_path = clone_root / repo_name
+    if local_path.exists():
+        return str(local_path.resolve())
+
+    clone_root.mkdir(parents=True, exist_ok=True)
+    result = _run(
+        ["git", "clone", f"https://github.com/{owner}/{repo_name}.git", str(local_path)],
+        check=False,
+        cwd=str(clone_root),
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"Failed to clone {repo}")
+    return str(local_path.resolve())
+
+
+def _resolve_repo_source(repo: str, *, clone_base: str) -> str:
+    candidate = Path(repo).expanduser()
+    if candidate.exists():
+        return str(candidate.resolve())
+
+    parsed = _parse_github_repo(repo)
+    if parsed is None:
+        raise RuntimeError(f"Repository '{repo}' was not found locally and is not a GitHub repo slug/URL")
+    return _clone_github_repo(repo, clone_base=clone_base)
+
+
+def _detect_base_ref(repo_path: str, configured_base_ref: str = "") -> str:
+    if configured_base_ref:
+        return configured_base_ref
+
+    remote_head = _git(
+        ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo_path,
+        check=False,
+    )
+    if remote_head:
+        return remote_head
+
+    current_branch = _detect_git_branch(repo_path)
+    if current_branch:
+        return current_branch
+    return "HEAD"
+
+
+def _local_branch_exists(repo_path: str, branch: str) -> bool:
+    result = _run(
+        ["git", "-C", repo_path, "show-ref", "--verify", f"refs/heads/{branch}"],
+        check=False,
+        timeout=5,
+    )
+    return result.returncode == 0
+
+
+def _fetch_base_ref(repo_path: str, base_ref: str) -> None:
+    if "/" not in base_ref:
+        return
+    remote = base_ref.split("/", 1)[0]
+    result = _run(["git", "-C", repo_path, "remote", "get-url", remote], check=False, timeout=5)
+    if result.returncode != 0:
+        return
+    _git(["fetch", remote], cwd=repo_path, check=False, timeout=30)
+
+
+def _prepare_worktree(repo_path: str, *, worktree_dir: Path, branch: str, base_ref: str) -> None:
+    if worktree_dir.exists():
+        raise RuntimeError(f"Worktree path already exists: {worktree_dir}")
+
+    if _local_branch_exists(repo_path, branch):
+        _git(["worktree", "add", str(worktree_dir), branch], cwd=repo_path)
+        return
+
+    _fetch_base_ref(repo_path, base_ref)
+    _git(["worktree", "add", "-b", branch, str(worktree_dir), base_ref], cwd=repo_path)
+
+
+class _TemplateDict(dict[str, str]):
+    def __missing__(self, key: str) -> str:  # pragma: no cover - defensive
+        raise RuntimeError(f"Unknown profile template key '{key}'")
+
+
+def _render_profile_value(value: str, context: dict[str, str]) -> str:
+    try:
+        return value.format_map(_TemplateDict(context))
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid profile template '{value}': {exc}") from exc
+
+
+def _profile_context(
+    *,
+    profile: SessionProfile,
+    name: str,
+    working_dir: str,
+    repo_path: str = "",
+    branch: str = "",
+    issue: int | None = None,
+    issue_title: str = "",
+    base_ref: str = "",
+) -> dict[str, str]:
+    profile_root = Path(working_dir) / ".tmux-pilot" / profile.name
+    session_dir = str(profile_root / "sessions")
+    context = {
+        "name": name,
+        "session_name": name,
+        "task_slug": _slugify_branch_component(name),
+        "worktree": working_dir,
+        "repo_path": repo_path,
+        "repo_name": Path(repo_path).name if repo_path else Path(working_dir).name,
+        "branch": branch,
+        "issue": str(issue) if issue is not None else "",
+        "issue_title": issue_title,
+        "base_ref": base_ref,
+        "profile": profile.name,
+        "profile_root": str(profile_root),
+        "session_dir": session_dir,
+    }
+    return context
+
+
+def _render_launch_command(profile: SessionProfile, context: dict[str, str]) -> str:
+    """Render the configured agent command for direct tmux startup."""
+    command_parts = [
+        _render_profile_value(part, context)
+        for part in profile.command_parts
+    ]
+    if not command_parts:
+        return ""
+
+    for key in ("profile_root", "session_dir"):
+        value = context.get(key, "")
+        if value:
+            Path(value).mkdir(parents=True, exist_ok=True)
+
+    env_parts = [
+        f"{key}={shlex.quote(_render_profile_value(value, context))}"
+        for key, value in profile.env.items()
+    ]
+    return " ".join(env_parts + [shlex.quote(part) for part in command_parts])
+
+
+def _initial_prompt_desc(desc: str | None, issue_title: str) -> str | None:
+    return issue_title or desc
+
+
+def _create_bootstrap_workspace(
+    *,
+    profile: SessionProfile,
+    name: str,
+    repo_source: str,
+    issue: int | None = None,
+    branch: str | None = None,
+    base_ref: str | None = None,
+) -> dict[str, str]:
+    repo_path = _resolve_repo_source(repo_source, clone_base=profile.clone_base)
+    worktree_base = Path(profile.worktree_base).expanduser().resolve()
+    worktree_dir = worktree_base / f"{Path(repo_path).name}-{name}"
+
+    branch_name = branch or f"{profile.branch_prefix}/{_slugify_branch_component(name)}"
+    if issue is not None and branch is None:
+        branch_name = f"{profile.branch_prefix}/{issue}-{_slugify_branch_component(name)}"
+
+    resolved_base_ref = _detect_base_ref(repo_path, base_ref or profile.base_ref)
+    _prepare_worktree(repo_path, worktree_dir=worktree_dir, branch=branch_name, base_ref=resolved_base_ref)
+
+    return {
+        "repo": repo_path,
+        "worktree": str(worktree_dir),
+        "branch": branch_name,
+        "base_ref": resolved_base_ref,
+    }
 
 
 def create_profile_session(
@@ -487,12 +870,15 @@ def create_profile_session(
     issue: int | None = None,
     agent: str | None = None,
     repo: str | None = None,
+    directory: str | None = None,
+    branch: str | None = None,
+    base_ref: str | None = None,
     no_agent: bool = False,
     prompt: str | None = None,
     desc: str | None = None,
     config_path: Path | None = None,
 ) -> dict[str, str]:
-    """Create a worktree-backed tmux session from a resolved profile."""
+    """Create a configured tmux session, optionally bootstrapped from a repo task."""
     profile = resolve_session_profile(
         profile_name,
         issue=issue,
@@ -500,44 +886,72 @@ def create_profile_session(
         agent_override=agent,
         path=config_path,
     )
-    if profile is None or not profile.repo:
-        raise RuntimeError("No repo configured for profile-based session creation")
+    if profile is None:
+        raise RuntimeError("No profile, agent, or repo bootstrap configuration was resolved")
 
-    repo_path = str(Path(profile.repo).expanduser().resolve())
-    worktree_base = Path(profile.worktree_base).expanduser().resolve()
-    worktree_dir = worktree_base / f"{Path(repo_path).name}-{name}"
+    repo_source = profile.repo
+    if not repo_source and (issue is not None or branch or base_ref):
+        repo_source = _git_root(directory or os.getcwd())
+    if issue is not None and not repo_source:
+        raise RuntimeError("Issue-based sessions require a git repo; pass --repo or run tp from a git checkout")
+    if (branch or base_ref) and not repo_source:
+        raise RuntimeError("Branch/base-ref options require a git repo; pass --repo or run tp from a git checkout")
 
-    branch_slug = _slugify_branch_component(name)
-    branch = f"{profile.branch_prefix}/{branch_slug}"
-    if issue is not None:
-        branch = f"{profile.branch_prefix}/{issue}-{branch_slug}"
+    issue_title = _fetch_issue_title(_resolve_repo_source(repo_source, clone_base=profile.clone_base), issue) if issue is not None and repo_source else ""
 
-    issue_title = _fetch_issue_title(repo_path, issue) if issue is not None else ""
+    workspace: dict[str, str] = {}
+    working_dir = ""
+    if repo_source:
+        workspace = _create_bootstrap_workspace(
+            profile=profile,
+            name=name,
+            repo_source=repo_source,
+            issue=issue,
+            branch=branch,
+            base_ref=base_ref,
+        )
+        working_dir = workspace["worktree"]
+    else:
+        working_dir = str(Path(directory or os.getcwd()).expanduser().resolve())
 
-    _git(["fetch", "origin"], cwd=repo_path)
-    _git(
-        ["worktree", "add", "-b", branch, str(worktree_dir), "origin/main"],
-        cwd=repo_path,
-    )
+    session_desc = _initial_prompt_desc(desc, issue_title)
+    rendered_command = ""
+    if not no_agent and profile.command_parts:
+        context = _profile_context(
+            profile=profile,
+            name=name,
+            working_dir=working_dir,
+            repo_path=workspace.get("repo", _git_root(working_dir)),
+            branch=workspace.get("branch", _detect_git_branch(working_dir)),
+            issue=issue,
+            issue_title=issue_title,
+            base_ref=workspace.get("base_ref", base_ref or ""),
+        )
+        rendered_command = _render_launch_command(profile, context)
 
-    new_session(name, directory=str(worktree_dir), desc=issue_title or desc)
-    set_metadata(name, "repo", repo_path)
-    set_metadata(name, "branch", branch)
-    set_metadata(name, "status", "active")
+    new_session(name, directory=working_dir, desc=session_desc, command=rendered_command or None)
+
+    repo_path = workspace.get("repo", _git_root(working_dir))
+    branch_name = workspace.get("branch", _detect_git_branch(working_dir))
+    set_metadata(name, "task", name)
+    if repo_path:
+        set_metadata(name, "repo", repo_path)
+    if branch_name:
+        set_metadata(name, "branch", branch_name)
+    if repo_path or profile.command_parts or no_agent:
+        set_metadata(name, "status", "active")
     if issue_title:
         set_metadata(name, "desc", issue_title)
 
-    if not no_agent and profile.agent:
-        _launch_agent(name, profile.agent, profile.agent_args)
-        if prompt:
-            time.sleep(5)
-            send_keys(name, prompt)
+    if rendered_command and prompt:
+        wait_until_session_ready(name, timeout=profile.prompt_wait_timeout)
+        send_keys(name, prompt)
 
     return {
         "repo": repo_path,
-        "worktree": str(worktree_dir),
-        "branch": branch,
-        "agent": profile.agent,
+        "worktree": working_dir,
+        "branch": branch_name,
+        "agent": rendered_command or " ".join(profile.command_parts),
         "desc": issue_title or desc or "",
     }
 
@@ -608,8 +1022,8 @@ def wait_until_session_ready(
 
     from . import agent_sessions
 
-    pane_cmd, pane_path, _pane_pid, _meta = _session_pane_details(name)
-    detected_process = _detect_process(pane_cmd, name)
+    pane_cmd, pane_path, pane_pid, _meta = _session_pane_details(name)
+    detected_process = _detect_process(pane_cmd, name, pane_pid)
     transcript_path: Path | None = None
     deadline = time.monotonic() + timeout
 
@@ -755,13 +1169,13 @@ def get_session_status(name: str) -> dict:
     scrollback = peek_session(name, lines=5)
     agent = _get_agent_state(
         name,
-        _detect_process(pane_cmd, name),
+        _detect_process(pane_cmd, name, pane_pid),
         pane_path=pane_path,
     )
 
     return {
         "name": name,
-        "process": _detect_process(pane_cmd, name),
+        "process": _detect_process(pane_cmd, name, pane_pid),
         "pid": pane_pid,
         "working_dir": pane_path,
         "metadata": meta,

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -43,6 +43,8 @@ PROFILE_CONFIG_PATH = Path.home() / ".config" / "tmux-pilot" / "profiles.toml"
 _DEFAULT_CLONE_BASE = "~/repos"
 _DEFAULT_WORKTREE_BASE = "~/worktrees"
 _SEND_KEYS_SETTLE_DELAY = 0.1
+_CWD_VERIFY_TIMEOUT = 2.0
+_CWD_VERIFY_INTERVAL = 0.05
 _PI_SESSION_DIR_TEMPLATE = "{worktree}/.tmux-pilot/pi/sessions"
 _BUILTIN_PROFILE_DEFS: dict[str, dict[str, object]] = {
     "codex": {
@@ -148,7 +150,7 @@ def _process_command_line(pane_pid: str = "") -> str:
     command_line = _raw_process_command_line(current_pid)
 
     while command_line:
-        base = Path(command_line.split()[0]).name.lower()
+        base = Path(command_line.split()[0]).name.lower().lstrip("-")
         if base not in {"zsh", "bash", "fish", "sh"}:
             return command_line
 
@@ -168,8 +170,9 @@ def _detect_process(pane_cmd: str, session_name: str = "", pane_pid: str = "") -
     if _VERSION_RE.match(cmd):
         return "claude-code"
     cmd_lower = cmd.lower()
+    shell_cmd = cmd_lower.lstrip("-")
     child_cmd = _process_command_line(pane_pid).lower()
-    if cmd_lower in {"zsh", "bash", "fish", "sh"} and child_cmd and child_cmd != cmd_lower:
+    if shell_cmd in {"zsh", "bash", "fish", "sh"} and child_cmd and child_cmd != cmd_lower:
         for key, alias in PROCESS_ALIASES.items():
             if key in child_cmd:
                 return alias
@@ -338,6 +341,69 @@ def peek_session(name: str, lines: int = 50, timeout: int = 3) -> str:
     return _tmux("capture-pane", "-t", name, "-p", "-S", f"-{lines}", check=True, timeout=timeout)
 
 
+def _normalize_directory(path: str) -> str:
+    """Resolve a working directory path for stable comparisons."""
+    if not path:
+        return ""
+    try:
+        return str(Path(path).expanduser().resolve())
+    except OSError:
+        return str(Path(path).expanduser())
+
+
+def _pane_current_path(session_name: str) -> str:
+    """Return the tmux pane's current working directory."""
+    return _tmux("display-message", "-t", session_name, "-p", "#{pane_current_path}", check=False)
+
+
+def _wait_for_pane_path(
+    session_name: str,
+    expected_cwd: str,
+    *,
+    timeout: float = _CWD_VERIFY_TIMEOUT,
+    interval: float = _CWD_VERIFY_INTERVAL,
+) -> str:
+    """Poll until the pane cwd matches *expected_cwd*, returning the last observed path."""
+    expected = _normalize_directory(expected_cwd)
+    deadline = time.monotonic() + timeout
+    current = _pane_current_path(session_name)
+    while _normalize_directory(current) != expected and time.monotonic() < deadline:
+        time.sleep(interval)
+        current = _pane_current_path(session_name)
+    return current
+
+
+def _ensure_session_cwd(session_name: str, expected_cwd: str) -> str:
+    """Repair a drifted shell cwd before launching an agent."""
+    expected = _normalize_directory(expected_cwd)
+    current = _pane_current_path(session_name)
+    if _normalize_directory(current) == expected:
+        return expected
+
+    send_keys(session_name, f"cd {shlex.quote(expected)}")
+    current = _wait_for_pane_path(session_name, expected)
+    if _normalize_directory(current) != expected:
+        current_display = current or "<unknown>"
+        raise RuntimeError(
+            f"Session '{session_name}' pane cwd is '{current_display}', expected '{expected}'. "
+            "tmux-pilot will not launch the agent until the pane is in the requested directory."
+        )
+    return expected
+
+
+def _verify_session_cwd_after_launch(session_name: str, expected_cwd: str) -> str:
+    """Fail loudly if the launched agent leaves the requested cwd immediately."""
+    expected = _normalize_directory(expected_cwd)
+    current = _wait_for_pane_path(session_name, expected)
+    if _normalize_directory(current) != expected:
+        current_display = current or "<unknown>"
+        raise RuntimeError(
+            f"Session '{session_name}' pane cwd changed to '{current_display}' after launching the agent; "
+            f"expected '{expected}'."
+        )
+    return expected
+
+
 def send_keys(name: str, text: str) -> None:
     """Send literal text, then press Enter in a separate tmux call.
 
@@ -377,14 +443,20 @@ def session_exists(name: str) -> bool:
     return result.returncode == 0
 
 
+def _exec_tmux_attach(target: str) -> None:
+    """Replace the current process with `tmux attach-session`."""
+    os.execvp("tmux", ["tmux", "attach-session", "-t", target])
+
+
 def _attach_or_switch(target: str) -> None:
     """Attach or switch to a session by exact name."""
     if _is_inside_tmux():
         _tmux("switch-client", "-t", target)
     else:
-        result = _run(["tmux", "attach-session", "-t", target], check=False, capture=False)
-        if result.returncode != 0:
-            raise RuntimeError(f"Failed to attach to session '{target}'")
+        try:
+            _exec_tmux_attach(target)
+        except OSError as exc:
+            raise RuntimeError(f"Failed to attach to session '{target}'") from exc
 
 
 def _resolve_session(name: str) -> str:
@@ -566,12 +638,21 @@ def should_use_profile_mode(
     base_ref: str | None = None,
     no_agent: bool = False,
     prompt: str | None = None,
+    directory: str | None = None,
     path: Path | None = None,
 ) -> bool:
     """Return True when `tp new` should use profile-backed creation."""
-    if profile_name or issue is not None or agent or repo or branch or base_ref or no_agent or prompt:
+    profiles = load_profiles(path)
+
+    if profile_name or issue is not None or repo or branch or base_ref or no_agent:
         return True
-    return "default" in load_profiles(path)
+    if agent:
+        return False
+    if prompt:
+        return "default" in profiles and not directory
+    if directory:
+        return False
+    return "default" in profiles
 
 
 def resolve_session_profile(
@@ -665,6 +746,24 @@ def _fetch_issue_title(repo_path: str, issue_number: int) -> str:
     return result.stdout.strip()
 
 
+def launch_agent_session(
+    session_name: str,
+    command: str,
+    *,
+    prompt: str | None = None,
+    expected_cwd: str | None = None,
+    prompt_timeout: float = 30.0,
+) -> None:
+    """Launch a shell command in a tmux session and optionally send a prompt."""
+    if expected_cwd:
+        _ensure_session_cwd(session_name, expected_cwd)
+    send_keys(session_name, command)
+    if expected_cwd:
+        _verify_session_cwd_after_launch(session_name, expected_cwd)
+    if prompt:
+        send_text(session_name, prompt, wait=True, timeout=prompt_timeout)
+
+
 def _git_root(path: str) -> str:
     """Return the git root for *path*, or an empty string when not in a repo."""
     if not path:
@@ -675,6 +774,62 @@ def _git_root(path: str) -> str:
         timeout=3,
     )
     return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def inspect_directory_context(directory: str) -> dict[str, str]:
+    """Inspect a directory and derive git-aware session metadata."""
+    resolved_dir = _normalize_directory(directory)
+    repo_root = _git_root(resolved_dir)
+    branch = _detect_git_branch(resolved_dir) if repo_root else ""
+    origin = ""
+    if repo_root:
+        origin = "git-worktree" if _is_git_worktree(repo_root) else "git-repo"
+
+    return {
+        "directory": resolved_dir,
+        "repo": repo_root or resolved_dir,
+        "branch": branch,
+        "origin": origin,
+    }
+
+
+def infer_session_name_for_directory(directory: str) -> str:
+    """Infer a tmux session name from a directory or its repo/worktree root."""
+    context = inspect_directory_context(directory)
+    raw_name = Path(context["repo"]).name or Path(context["directory"]).name
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", raw_name).strip("-")
+    if not name:
+        raise RuntimeError(
+            f"Could not infer a session name from '{context['directory']}'. "
+            "Pass an explicit session name."
+        )
+    return name
+
+
+def uniqueify_session_name(base_name: str) -> str:
+    """Return *base_name* or the next available -N suffixed variant."""
+    if not session_exists(base_name):
+        return base_name
+
+    suffix = 1
+    while True:
+        candidate = f"{base_name}-{suffix}"
+        if not session_exists(candidate):
+            return candidate
+        suffix += 1
+
+
+def apply_directory_metadata(session_name: str, directory: str) -> dict[str, str]:
+    """Set repo/branch/origin metadata for a session from a local directory."""
+    context = inspect_directory_context(directory)
+
+    set_metadata(session_name, "repo", context["repo"])
+    if context["branch"]:
+        set_metadata(session_name, "branch", context["branch"])
+    if context["origin"]:
+        set_metadata(session_name, "origin", context["origin"])
+
+    return context
 
 
 def _parse_github_repo(repo: str) -> tuple[str, str] | None:
@@ -933,7 +1088,7 @@ def create_profile_session(
         )
         rendered_command = _render_launch_command(profile, context)
 
-    new_session(name, directory=working_dir, desc=session_desc, command=rendered_command or None)
+    new_session(name, directory=working_dir, desc=session_desc)
 
     repo_path = workspace.get("repo", _git_root(working_dir))
     branch_name = workspace.get("branch", _detect_git_branch(working_dir))
@@ -947,9 +1102,14 @@ def create_profile_session(
     if issue_title:
         set_metadata(name, "desc", issue_title)
 
-    if rendered_command and prompt:
-        wait_until_session_ready(name, timeout=profile.prompt_wait_timeout)
-        send_keys(name, prompt)
+    if rendered_command:
+        launch_agent_session(
+            name,
+            rendered_command,
+            prompt=prompt,
+            expected_cwd=working_dir,
+            prompt_timeout=profile.prompt_wait_timeout,
+        )
 
     return {
         "repo": repo_path,

--- a/src/tmux_pilot/plugins/agents/__init__.py
+++ b/src/tmux_pilot/plugins/agents/__init__.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import claude_code, codex, generic
+from . import claude_code, codex, generic, pi
 from ... import core
 
-_PLUGINS = (claude_code, codex, generic)
+_PLUGINS = (claude_code, codex, pi, generic)
 
 
 def get_agent_state(

--- a/src/tmux_pilot/plugins/agents/pi.py
+++ b/src/tmux_pilot/plugins/agents/pi.py
@@ -1,0 +1,83 @@
+"""Built-in agent plugin for Pi sessions."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ... import agent_sessions
+from ... import core
+
+_TERMINAL_STATES = {"completed", "interrupted", "error"}
+_FOOTER_RE = re.compile(
+    r"\([a-z0-9_.-]+\)\s+[a-z0-9_.-]+(?:\s+•\s+(?:thinking off|off|minimal|low|medium|high|xhigh))?$",
+    re.IGNORECASE,
+)
+
+
+def detect(pane_command: str, pane_output: str) -> bool:
+    """Detect Pi from its command name or startup/banner text."""
+    command = pane_command.strip().lower()
+    output = pane_output.lower()
+    return (
+        command == "pi"
+        or bool(re.search(r"\bpi v\d+\.\d+\.\d+\b", output))
+        or "/ for commands" in output
+    )
+
+
+def _nonempty_lines(text: str) -> list[str]:
+    return [line.rstrip() for line in text.splitlines() if line.strip()]
+
+
+def _looks_ready_for_input(pane_output: str) -> bool:
+    lines = _nonempty_lines(pane_output)
+    if any(line.strip() == "/ for commands" for line in lines):
+        return True
+    return any(_FOOTER_RE.search(line.strip()) for line in lines[-4:])
+
+
+def _state_from_output(pane_output: str) -> str:
+    if not pane_output.strip():
+        return "unknown"
+    if _looks_ready_for_input(pane_output):
+        return "idle"
+    return "running"
+
+
+def _merge_states(
+    pane_output: str,
+    pane_state: str,
+    transcript_state: agent_sessions.TranscriptState | None,
+) -> tuple[str, bool]:
+    if transcript_state is None:
+        return pane_state, pane_state in {"idle", "completed"}
+
+    if transcript_state.state == "running":
+        return "running", False
+
+    if transcript_state.state in _TERMINAL_STATES:
+        return transcript_state.state, _looks_ready_for_input(pane_output)
+
+    return pane_state, pane_state in {"idle", "completed"}
+
+
+def get_state(
+    session_name: str,
+    pane_output: str | None = None,
+    *,
+    working_dir: str = "",
+    transcript_path: Path | None = None,
+) -> dict[str, str | bool]:
+    """Return Pi state using session transcripts when available."""
+    pane_output = pane_output or core.peek_session(session_name, lines=200)
+    transcript_state = agent_sessions.get_pi_transcript_state(
+        working_dir,
+        transcript_path=transcript_path,
+    ) if working_dir else None
+    state, ready = _merge_states(pane_output, _state_from_output(pane_output), transcript_state)
+    return {
+        "type": "pi",
+        "state": state,
+        "ready": ready,
+    }

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tmux_pilot import agent_sessions, core, display
-from tmux_pilot.plugins.agents import claude_code, codex, generic, get_agent_state
+from tmux_pilot.plugins.agents import claude_code, codex, generic, get_agent_state, pi
 
 
 def test_claude_code_detects_version_string():
@@ -184,6 +184,48 @@ def test_generic_uses_prompt_regex(monkeypatch):
     state = generic.get_state("alpha")
 
     assert state == {"type": "generic", "state": "idle", "ready": True}
+
+
+def test_pi_detects_banner_output():
+    assert pi.detect("node", "pi v0.55.3\n/ for commands")
+
+
+def test_pi_reports_idle_from_footer(monkeypatch):
+    pane = """
+pi v0.55.3
+/ for commands
+
+~/tmp/project
+$0.000 (sub) 0.0%/200k (auto)               (anthropic) claude-opus-4-6 • medium
+"""
+    monkeypatch.setattr(core, "peek_session", lambda session_name, lines=200: pane)
+
+    state = pi.get_state("alpha")
+
+    assert state == {"type": "pi", "state": "idle", "ready": True}
+
+
+def test_pi_transcript_running_overrides_idle_pane(monkeypatch):
+    pane = """
+pi v0.55.3
+/ for commands
+
+~/tmp/project
+$0.000 (sub) 0.0%/200k (auto)               (anthropic) claude-opus-4-6 • medium
+"""
+    monkeypatch.setattr(core, "peek_session", lambda session_name, lines=200: pane)
+    monkeypatch.setattr(
+        agent_sessions,
+        "get_pi_transcript_state",
+        lambda cwd, transcript_path=None: agent_sessions.TranscriptState(
+            path=Path("/tmp/pi-session.jsonl"),
+            state="running",
+        ),
+    )
+
+    state = pi.get_state("alpha", working_dir="/tmp/example")
+
+    assert state == {"type": "pi", "state": "running", "ready": False}
 
 
 def test_registry_selects_codex_plugin(monkeypatch):

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -195,3 +195,60 @@ def test_get_claude_transcript_state_resolves_path_from_cwd(tmp_path: Path):
         timestamp="2026-03-29T20:00:09Z",
         turn_id="msg-9",
     )
+
+
+def test_find_pi_transcript_for_cwd_uses_worktree_session_dir(tmp_path: Path):
+    worktree = tmp_path / "worktree"
+    session_dir = worktree / ".tmux-pilot" / "pi" / "sessions"
+    transcript = session_dir / "session.jsonl"
+    _write(
+        transcript,
+        [
+            f'{{"type":"session","version":3,"id":"pi-1","timestamp":"2026-03-29T20:00:00Z","cwd":"{worktree}"}}\n',
+            '{"type":"message","id":"msg-1","parentId":null,"timestamp":"2026-03-29T20:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop"}}\n',
+        ],
+    )
+
+    found = agent_sessions.find_pi_transcript_for_cwd(str(worktree))
+
+    assert found == transcript
+
+
+def test_read_pi_transcript_state_reports_running_from_tool_use(tmp_path: Path):
+    transcript = tmp_path / "sessions" / "pi.jsonl"
+    _write(
+        transcript,
+        [
+            '{"type":"session","version":3,"id":"pi-1","timestamp":"2026-03-29T20:00:00Z","cwd":"/tmp/project"}\n',
+            '{"type":"message","id":"msg-1","parentId":null,"timestamp":"2026-03-29T20:00:01Z","message":{"role":"assistant","content":[{"type":"toolCall","name":"bash","id":"tool-1","arguments":{"command":"pwd"}}],"stopReason":"toolUse"}}\n',
+        ],
+    )
+
+    state = agent_sessions.read_pi_transcript_state(transcript)
+
+    assert state == agent_sessions.TranscriptState(
+        path=transcript,
+        state="running",
+        timestamp="2026-03-29T20:00:01Z",
+        turn_id="msg-1",
+    )
+
+
+def test_read_pi_transcript_state_reports_completed_from_assistant_stop(tmp_path: Path):
+    transcript = tmp_path / "sessions" / "pi.jsonl"
+    _write(
+        transcript,
+        [
+            '{"type":"session","version":3,"id":"pi-1","timestamp":"2026-03-29T20:00:00Z","cwd":"/tmp/project"}\n',
+            '{"type":"message","id":"msg-2","parentId":null,"timestamp":"2026-03-29T20:00:03Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"stopReason":"stop"}}\n',
+        ],
+    )
+
+    state = agent_sessions.read_pi_transcript_state(transcript)
+
+    assert state == agent_sessions.TranscriptState(
+        path=transcript,
+        state="completed",
+        timestamp="2026-03-29T20:00:03Z",
+        turn_id="msg-2",
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -217,6 +217,15 @@ class TestSessionLifecycle:
         session = core.list_sessions()[0]
         assert session.desc == "meta test"
 
+    def test_list_sessions_detects_pi_process_from_pid(self, fake_tmux: FakeTmux, monkeypatch: pytest.MonkeyPatch):
+        core.new_session(TEST_SESSION)
+        fake_tmux.sessions[TEST_SESSION]["command"] = "node"
+        monkeypatch.setattr(core, "_process_command_line", lambda pane_pid="": "pi")
+
+        session = core.list_sessions()[0]
+
+        assert session.process == "pi"
+
 
 class TestMetadata:
     def test_set_and_get(self, fake_tmux: FakeTmux):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import subprocess
 
 import pytest
@@ -26,6 +27,8 @@ class FakeTmux:
         self.switched_to: str | None = None
         self.attached_to: str | None = None
         self.send_key_calls: list[tuple[str, bool, list[str]]] = []
+        self.ignore_cd = False
+        self.path_after_commands: dict[str, str] = {}
 
     def run(
         self,
@@ -129,6 +132,13 @@ class FakeTmux:
                 if key == "Enter":
                     text = str(session["input_buffer"])
                     scrollback = f"$ {text}\n"
+                    parts = shlex.split(text) if text else []
+                    if parts and parts[0] == "cd" and len(parts) > 1 and not self.ignore_cd:
+                        session["path"] = parts[1]
+                    for prefix, path in self.path_after_commands.items():
+                        if text == prefix or text.startswith(prefix + " "):
+                            session["path"] = path
+                            break
                     if text.startswith("echo "):
                         scrollback += text[5:] + "\n"
                     session["scrollback"] = str(session["scrollback"]) + scrollback
@@ -226,6 +236,17 @@ class TestSessionLifecycle:
 
         assert session.process == "pi"
 
+    def test_detect_process_follows_login_shell_children(self, monkeypatch: pytest.MonkeyPatch):
+        command_lines = {
+            "1000": "-zsh",
+            "2000": "node /usr/local/bin/pi --session-dir /tmp/pi",
+        }
+
+        monkeypatch.setattr(core, "_raw_process_command_line", lambda pid="": command_lines.get(pid, ""))
+        monkeypatch.setattr(core, "_child_pids", lambda pid: ["2000"] if pid == "1000" else [])
+
+        assert core._detect_process("node", pane_pid="1000") == "pi"
+
 
 class TestMetadata:
     def test_set_and_get(self, fake_tmux: FakeTmux):
@@ -242,6 +263,83 @@ class TestMetadata:
         core.set_metadata(TEST_SESSION, "status", "running")
         core.set_metadata(TEST_SESSION, "status", "done")
         assert core.get_metadata(TEST_SESSION, "status") == "done"
+
+
+class TestDirectoryMetadata:
+    def test_infer_session_name_uses_repo_root(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            core,
+            "inspect_directory_context",
+            lambda directory: {
+                "directory": "/repo/worktree/src",
+                "repo": "/repo/worktree",
+                "branch": "feat/example",
+                "origin": "git-worktree",
+            },
+        )
+
+        assert core.infer_session_name_for_directory("/repo/worktree/src") == "worktree"
+
+    def test_infer_session_name_uses_directory_when_not_in_git(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            core,
+            "inspect_directory_context",
+            lambda directory: {
+                "directory": "/tmp/plain-dir",
+                "repo": "/tmp/plain-dir",
+                "branch": "",
+                "origin": "",
+            },
+        )
+
+        assert core.infer_session_name_for_directory("/tmp/plain-dir") == "plain-dir"
+
+    def test_uniqueify_session_name_adds_numeric_suffix(self, monkeypatch: pytest.MonkeyPatch):
+        existing = {"agentic-trace-analyzer", "agentic-trace-analyzer-1", "agentic-trace-analyzer-2"}
+        monkeypatch.setattr(core, "session_exists", lambda name: name in existing)
+
+        assert core.uniqueify_session_name("agentic-trace-analyzer") == "agentic-trace-analyzer-3"
+
+    def test_apply_directory_metadata_uses_git_context(self, monkeypatch: pytest.MonkeyPatch):
+        metadata_calls: list[tuple[str, str, str]] = []
+
+        monkeypatch.setattr(core, "_git_root", lambda path: "/repo/worktree")
+        monkeypatch.setattr(core, "_detect_git_branch", lambda path: "feat/example")
+        monkeypatch.setattr(core, "_is_git_worktree", lambda path: True)
+        monkeypatch.setattr(core, "set_metadata", lambda session_name, key, value: metadata_calls.append((session_name, key, value)))
+
+        context = core.apply_directory_metadata(TEST_SESSION, "/repo/worktree")
+
+        assert context == {
+            "directory": "/repo/worktree",
+            "repo": "/repo/worktree",
+            "branch": "feat/example",
+            "origin": "git-worktree",
+        }
+        assert metadata_calls == [
+            (TEST_SESSION, "repo", "/repo/worktree"),
+            (TEST_SESSION, "branch", "feat/example"),
+            (TEST_SESSION, "origin", "git-worktree"),
+        ]
+
+    def test_apply_directory_metadata_uses_directory_when_not_in_git(self, monkeypatch: pytest.MonkeyPatch):
+        metadata_calls: list[tuple[str, str, str]] = []
+        expected_dir = core._normalize_directory("/tmp/plain")
+
+        monkeypatch.setattr(core, "_git_root", lambda path: "")
+        monkeypatch.setattr(core, "set_metadata", lambda session_name, key, value: metadata_calls.append((session_name, key, value)))
+
+        context = core.apply_directory_metadata(TEST_SESSION, "/tmp/plain")
+
+        assert context == {
+            "directory": expected_dir,
+            "repo": expected_dir,
+            "branch": "",
+            "origin": "",
+        }
+        assert metadata_calls == [
+            (TEST_SESSION, "repo", expected_dir),
+        ]
 
 
 class TestPeekAndSend:
@@ -365,6 +463,19 @@ class TestResolveSession:
         core.new_session(TEST_SESSION + "_2")
         with pytest.raises(RuntimeError, match="matches multiple"):
             core._resolve_session("_tp_test")
+
+    def test_attach_or_switch_execs_tmux_when_attaching_outside_tmux(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        calls: list[str] = []
+
+        monkeypatch.setattr(core, "_is_inside_tmux", lambda: False)
+        monkeypatch.setattr(core, "_exec_tmux_attach", lambda target: calls.append(target))
+
+        core._attach_or_switch("demo")
+
+        assert calls == ["demo"]
 
 
 class TestStatus:
@@ -611,3 +722,210 @@ class TestCLI:
 
         assert exc_info.value.code == 1
         assert "boom" in capsys.readouterr().err
+
+    def test_new_with_agent_and_prompt_uses_plain_mode(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        new_calls: list[tuple[str, str | None, str | None]] = []
+        launch_calls: list[tuple[str, str, str | None, str | None]] = []
+
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+        monkeypatch.setattr(
+            core,
+            "new_session",
+            lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc)),
+        )
+        monkeypatch.setattr(
+            core,
+            "launch_agent_session",
+            lambda session_name, command, *, prompt=None, expected_cwd=None, prompt_timeout=30.0: launch_calls.append((session_name, command, prompt, expected_cwd)),
+        )
+        monkeypatch.setattr(
+            core,
+            "create_profile_session",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not use profile mode")),
+        )
+
+        cli_main(["new", "foo-codex-test-4", "--agent", "codex", "--prompt", "1+3"])
+
+        assert new_calls == [("foo-codex-test-4", None, None)]
+        assert launch_calls == [("foo-codex-test-4", "codex", "1+3", None)]
+        assert "Created session 'foo-codex-test-4'" in capsys.readouterr().out
+
+    def test_new_with_agent_and_directory_passes_expected_cwd(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        launch_calls: list[tuple[str, str, str | None, str | None]] = []
+        expected_cwd = "/tmp/worktree"
+
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+        monkeypatch.setattr(core, "new_session", lambda name, *, directory=None, desc=None, command=None: None)
+        monkeypatch.setattr(
+            core,
+            "launch_agent_session",
+            lambda session_name, command, *, prompt=None, expected_cwd=None, prompt_timeout=30.0: launch_calls.append((session_name, command, prompt, expected_cwd)),
+        )
+
+        cli_main(["new", "foo", "-c", expected_cwd, "--agent", "codex"])
+
+        assert launch_calls == [("foo", "codex", None, expected_cwd)]
+        assert "Created session 'foo'" in capsys.readouterr().out
+
+    def test_new_with_here_applies_directory_metadata_and_can_jump(self, monkeypatch: pytest.MonkeyPatch):
+        launch_calls: list[tuple[str, str, str | None, str | None]] = []
+        metadata_calls: list[tuple[str, str]] = []
+        jump_calls: list[str] = []
+        current_dir = "/tmp/worktree"
+
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+        monkeypatch.setattr(core, "new_session", lambda name, *, directory=None, desc=None, command=None: None)
+        monkeypatch.setattr(core, "infer_session_name_for_directory", lambda directory: "worktree")
+        monkeypatch.setattr(core, "apply_directory_metadata", lambda session_name, directory: metadata_calls.append((session_name, directory)) or {})
+        monkeypatch.setattr(
+            core,
+            "launch_agent_session",
+            lambda session_name, command, *, prompt=None, expected_cwd=None, prompt_timeout=30.0: launch_calls.append((session_name, command, prompt, expected_cwd)),
+        )
+        monkeypatch.setattr(core, "jump_session", lambda name: jump_calls.append(name))
+        monkeypatch.setattr("tmux_pilot.cli.os.getcwd", lambda: current_dir)
+
+        cli_main(["new", "--here", "--agent", "codex", "--jump"])
+
+        assert metadata_calls == [("worktree", current_dir)]
+        assert launch_calls == [("worktree", "codex", None, current_dir)]
+        assert jump_calls == ["worktree"]
+
+    def test_new_here_conflicts_with_directory(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main(["new", "foo", "--here", "-c", "/tmp/other"])
+
+        assert exc_info.value.code == 1
+        assert "--here cannot be combined with --directory" in capsys.readouterr().err
+
+    def test_new_without_name_uses_directory_name(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        new_calls: list[tuple[str, str | None, str | None]] = []
+
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+        monkeypatch.setattr(core, "infer_session_name_for_directory", lambda directory: "my-worktree")
+        monkeypatch.setattr(
+            core,
+            "new_session",
+            lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc)),
+        )
+
+        cli_main(["new", "-c", "/tmp/my-worktree"])
+
+        assert new_calls == [("my-worktree", "/tmp/my-worktree", None)]
+        assert "Created session 'my-worktree'" in capsys.readouterr().out
+
+    def test_new_without_name_auto_uniqueifies_inferred_name(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        new_calls: list[tuple[str, str | None, str | None]] = []
+        existing = {"agentic-trace-analyzer", "agentic-trace-analyzer-1"}
+        current_dir = "/tmp/agentic-trace-analyzer"
+
+        monkeypatch.setattr(core, "session_exists", lambda name: name in existing)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+        monkeypatch.setattr(core, "infer_session_name_for_directory", lambda directory: "agentic-trace-analyzer")
+        monkeypatch.setattr("tmux_pilot.cli.os.getcwd", lambda: current_dir)
+        monkeypatch.setattr(core, "apply_directory_metadata", lambda session_name, directory: {})
+        monkeypatch.setattr(
+            core,
+            "new_session",
+            lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc)),
+        )
+
+        cli_main(["new", "--here"])
+
+        assert new_calls == [("agentic-trace-analyzer-2", current_dir, None)]
+        assert "Created session 'agentic-trace-analyzer-2'" in capsys.readouterr().out
+
+    def test_new_without_name_errors_when_no_directory_context(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main(["new"])
+
+        assert exc_info.value.code == 1
+        assert "Session name is required unless --directory or --here is provided." in capsys.readouterr().err
+
+    def test_launch_agent_session_waits_before_prompt(self, monkeypatch: pytest.MonkeyPatch):
+        send_keys_calls: list[tuple[str, str]] = []
+        send_text_calls: list[tuple[str, str, bool, float]] = []
+
+        monkeypatch.setattr(core, "send_keys", lambda name, text: send_keys_calls.append((name, text)))
+        monkeypatch.setattr(
+            core,
+            "send_text",
+            lambda name, text, *, wait=False, timeout=30.0, interval=0.25: send_text_calls.append((name, text, wait, timeout)) or {},
+        )
+
+        core.launch_agent_session(TEST_SESSION, "codex", prompt="1+3", prompt_timeout=12.0)
+
+        assert send_keys_calls == [(TEST_SESSION, "codex")]
+        assert send_text_calls == [(TEST_SESSION, "1+3", True, 12.0)]
+
+    def test_launch_agent_session_restores_expected_cwd_before_launch(self, fake_tmux: FakeTmux, tmp_path):
+        expected_cwd = str(tmp_path)
+        core.new_session(TEST_SESSION, directory=expected_cwd)
+        fake_tmux.sessions[TEST_SESSION]["path"] = "/Users/cjm"
+
+        core.launch_agent_session(TEST_SESSION, "codex", expected_cwd=expected_cwd)
+
+        assert fake_tmux.sessions[TEST_SESSION]["path"] == expected_cwd
+        assert fake_tmux.send_key_calls == [
+            (TEST_SESSION, True, [f"cd {shlex.quote(expected_cwd)}"]),
+            (TEST_SESSION, False, ["Enter"]),
+            (TEST_SESSION, True, ["codex"]),
+            (TEST_SESSION, False, ["Enter"]),
+        ]
+
+    def test_launch_agent_session_raises_when_cwd_cannot_be_restored(
+        self,
+        fake_tmux: FakeTmux,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        expected_cwd = str(tmp_path)
+        core.new_session(TEST_SESSION, directory=expected_cwd)
+        fake_tmux.sessions[TEST_SESSION]["path"] = "/Users/cjm"
+        fake_tmux.ignore_cd = True
+        monkeypatch.setattr(core.time, "sleep", lambda seconds: None)
+        monotonic_values = iter([0.0, 0.5, 1.0, 3.0])
+        monkeypatch.setattr(core.time, "monotonic", lambda: next(monotonic_values))
+
+        with pytest.raises(RuntimeError, match="will not launch the agent"):
+            core.launch_agent_session(TEST_SESSION, "codex", expected_cwd=expected_cwd)
+
+        assert fake_tmux.send_key_calls == [
+            (TEST_SESSION, True, [f"cd {shlex.quote(expected_cwd)}"]),
+            (TEST_SESSION, False, ["Enter"]),
+        ]
+
+    def test_launch_agent_session_raises_when_agent_changes_cwd_after_launch(
+        self,
+        fake_tmux: FakeTmux,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        expected_cwd = str(tmp_path)
+        fake_tmux.path_after_commands["codex"] = "/Users/cjm"
+        core.new_session(TEST_SESSION, directory=expected_cwd)
+        monkeypatch.setattr(core.time, "sleep", lambda seconds: None)
+        monotonic_values = iter([0.0, 0.5, 1.0, 3.0])
+        monkeypatch.setattr(core.time, "monotonic", lambda: next(monotonic_values))
+
+        with pytest.raises(RuntimeError, match="changed to"):
+            core.launch_agent_session(TEST_SESSION, "codex", expected_cwd=expected_cwd)
+
+    def test_new_prompt_without_agent_errors_in_plain_mode(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(core, "load_profiles", lambda path=None: {})
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main(["new", "foo", "--prompt", "1+3"])
+
+        assert exc_info.value.code == 1
+        assert "--prompt requires --agent in plain mode" in capsys.readouterr().err

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,19 +1,20 @@
-"""Tests for profile-backed session creation."""
+"""Tests for profile-backed session creation and repo bootstrapping."""
 
 from __future__ import annotations
+
+import subprocess
 
 from pathlib import Path
 
 from tmux_pilot import core
 
 
-def test_resolve_session_profile_merges_default_values(tmp_path):
+def test_resolve_session_profile_merges_default_values_and_builtins(tmp_path):
     config = tmp_path / "profiles.toml"
     config.write_text(
         """
 [default]
-agent = "claude"
-agent_args = "--permission-mode bypassPermissions"
+extends = "claude"
 worktree_base = "~/worktrees"
 
 [dismech]
@@ -26,67 +27,156 @@ branch_prefix = "fix"
 
     assert profile is not None
     assert profile.repo == "~/repos/dismech"
-    assert profile.agent == "claude"
-    assert profile.agent_args == "--permission-mode bypassPermissions"
+    assert profile.command_parts == ("claude", "--permission-mode", "bypassPermissions")
     assert profile.worktree_base == "~/worktrees"
     assert profile.branch_prefix == "fix"
 
 
+def test_builtin_profiles_can_be_customized_from_config(tmp_path):
+    config = tmp_path / "profiles.toml"
+    config.write_text(
+        """
+[profiles.codex]
+command = ["codex", "--profile", "safe"]
+"""
+    )
+
+    profile = core.resolve_session_profile("codex", path=config)
+
+    assert profile is not None
+    assert profile.command_parts == ("codex", "--profile", "safe")
+
+
 def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monkeypatch, tmp_path):
     profile = core.SessionProfile(
-        name="dismech",
+        name="pi",
         repo="~/repos/dismech",
-        agent="codex",
-        agent_args="--profile yolo",
+        command=("pi", "--session-dir", "{session_dir}"),
         worktree_base=str(tmp_path),
         branch_prefix="fix",
+        prompt_wait_timeout=12.0,
     )
-    git_calls: list[tuple[list[str], str]] = []
     metadata_calls: list[tuple[str, str, str]] = []
     send_calls: list[tuple[str, str]] = []
-    new_calls: list[tuple[str, str | None, str | None]] = []
-    sleep_calls: list[int] = []
-
-    monkeypatch.setattr(core, "resolve_session_profile", lambda *args, **kwargs: profile)
-    monkeypatch.setattr(core, "_fetch_issue_title", lambda repo_path, issue_number: "Review Wilson")
-    monkeypatch.setattr(core, "_git", lambda args, *, cwd, check=True, timeout=15: git_calls.append((args, cwd)) or "")
-    monkeypatch.setattr(
-        core,
-        "new_session",
-        lambda name, *, directory=None, desc=None: new_calls.append((name, directory, desc)),
-    )
-    monkeypatch.setattr(core, "set_metadata", lambda *args: metadata_calls.append(args))
-    monkeypatch.setattr(core, "send_keys", lambda session_name, text: send_calls.append((session_name, text)))
-    monkeypatch.setattr(core.time, "sleep", lambda seconds: sleep_calls.append(seconds))
-
-    result = core.create_profile_session(
-        "review-wilson",
-        profile_name="dismech",
-        issue=771,
-        prompt="Summarize the issue and propose a fix.",
-    )
+    new_calls: list[tuple[str, str | None, str | None, str | None]] = []
+    wait_calls: list[tuple[str, float, float]] = []
 
     repo_path = str(Path("~/repos/dismech").expanduser().resolve())
     worktree_dir = tmp_path / "dismech-review-wilson"
 
-    assert git_calls == [
-        (["fetch", "origin"], repo_path),
-        (["worktree", "add", "-b", "fix/771-review-wilson", str(worktree_dir), "origin/main"], repo_path),
+    monkeypatch.setattr(core, "resolve_session_profile", lambda *args, **kwargs: profile)
+    monkeypatch.setattr(core, "_fetch_issue_title", lambda repo_path, issue_number: "Review Wilson")
+    monkeypatch.setattr(
+        core,
+        "_create_bootstrap_workspace",
+        lambda **kwargs: {
+            "repo": repo_path,
+            "worktree": str(worktree_dir),
+            "branch": "fix/771-review-wilson",
+            "base_ref": "origin/main",
+        },
+    )
+    monkeypatch.setattr(
+        core,
+        "new_session",
+        lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc, command)),
+    )
+    monkeypatch.setattr(core, "set_metadata", lambda *args: metadata_calls.append(args))
+    monkeypatch.setattr(core, "send_keys", lambda session_name, text: send_calls.append((session_name, text)))
+
+    def fake_wait(name: str, *, timeout: float, interval: float = 0.25):
+        wait_calls.append((name, timeout, interval))
+        return {"type": "pi", "state": "idle", "ready": True}
+
+    monkeypatch.setattr(core, "wait_until_session_ready", fake_wait)
+
+    result = core.create_profile_session(
+        "review-wilson",
+        profile_name="pi",
+        issue=771,
+        prompt="Summarize the issue and propose a fix.",
+    )
+
+    assert new_calls == [
+        (
+            "review-wilson",
+            str(worktree_dir),
+            "Review Wilson",
+            f"pi --session-dir {worktree_dir}/.tmux-pilot/pi/sessions",
+        )
     ]
-    assert new_calls == [("review-wilson", str(worktree_dir), "Review Wilson")]
     assert metadata_calls == [
+        ("review-wilson", "task", "review-wilson"),
         ("review-wilson", "repo", repo_path),
         ("review-wilson", "branch", "fix/771-review-wilson"),
         ("review-wilson", "status", "active"),
         ("review-wilson", "desc", "Review Wilson"),
     ]
-    assert send_calls == [
-        ("review-wilson", "codex --profile yolo"),
-        ("review-wilson", "Summarize the issue and propose a fix."),
-    ]
-    assert sleep_calls == [5]
+    assert send_calls == [("review-wilson", "Summarize the issue and propose a fix.")]
+    assert wait_calls == [("review-wilson", 12.0, 0.25)]
     assert result["branch"] == "fix/771-review-wilson"
     assert result["worktree"] == str(worktree_dir)
+
+
+def test_create_profile_session_launches_agent_in_directory_without_bootstrap(monkeypatch, tmp_path):
+    profile = core.SessionProfile(
+        name="codex",
+        command=("codex", "--profile", "yolo"),
+    )
+    metadata_calls: list[tuple[str, str, str]] = []
+    send_calls: list[tuple[str, str]] = []
+    new_calls: list[tuple[str, str | None, str | None, str | None]] = []
+
+    monkeypatch.setattr(core, "resolve_session_profile", lambda *args, **kwargs: profile)
+    monkeypatch.setattr(
+        core,
+        "new_session",
+        lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc, command)),
+    )
+    monkeypatch.setattr(core, "set_metadata", lambda *args: metadata_calls.append(args))
+    monkeypatch.setattr(core, "send_keys", lambda session_name, text: send_calls.append((session_name, text)))
+    monkeypatch.setattr(core, "_git_root", lambda path: "")
+    monkeypatch.setattr(core, "_detect_git_branch", lambda path: "")
+
+    result = core.create_profile_session(
+        "local-task",
+        profile_name="codex",
+        directory=str(tmp_path),
+    )
+
+    assert new_calls == [("local-task", str(tmp_path.resolve()), None, "codex --profile yolo")]
+    assert metadata_calls == [
+        ("local-task", "task", "local-task"),
+        ("local-task", "status", "active"),
+    ]
+    assert send_calls == []
+    assert result["worktree"] == str(tmp_path.resolve())
+
+
+def test_resolve_repo_source_clones_github_repo_when_missing(monkeypatch, tmp_path):
+    clone_calls: list[tuple[list[str], str | None]] = []
+
+    def fake_run(
+        args: list[str],
+        *,
+        check: bool = True,
+        capture: bool = True,
+        cwd: str | None = None,
+        timeout: int = 5,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, capture, timeout
+        clone_calls.append((args, cwd))
+        Path(args[-1]).mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(core, "_run", fake_run)
+
+    resolved = core._resolve_repo_source("acme/widgets", clone_base=str(tmp_path))
+
+    assert resolved == str((tmp_path / "widgets").resolve())
+    assert clone_calls == [
+        (["git", "clone", "https://github.com/acme/widgets.git", str(tmp_path / "widgets")], str(tmp_path))
+    ]
 
 
 def test_list_sessions_detects_branch_from_worktree(monkeypatch):
@@ -94,7 +184,7 @@ def test_list_sessions_detects_branch_from_worktree(monkeypatch):
     monkeypatch.setattr(
         core,
         "_tmux",
-        lambda *args, **kwargs: "alpha\tzsh\t/tmp/alpha\t\t\t\t\t\t\t\t\t",
+        lambda *args, **kwargs: "alpha\tzsh\t/tmp/alpha\t1234\t\t\t\t\t\t\t\t\t\t",
     )
     monkeypatch.setattr(core, "_detect_git_branch", lambda path: "feat/detected")
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -57,14 +57,14 @@ def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monke
         prompt_wait_timeout=12.0,
     )
     metadata_calls: list[tuple[str, str, str]] = []
-    send_calls: list[tuple[str, str]] = []
+    launch_calls: list[tuple[str, str, str | None, str | None, float]] = []
     new_calls: list[tuple[str, str | None, str | None, str | None]] = []
-    wait_calls: list[tuple[str, float, float]] = []
 
     repo_path = str(Path("~/repos/dismech").expanduser().resolve())
     worktree_dir = tmp_path / "dismech-review-wilson"
 
     monkeypatch.setattr(core, "resolve_session_profile", lambda *args, **kwargs: profile)
+    monkeypatch.setattr(core, "_resolve_repo_source", lambda repo, *, clone_base: repo_path)
     monkeypatch.setattr(core, "_fetch_issue_title", lambda repo_path, issue_number: "Review Wilson")
     monkeypatch.setattr(
         core,
@@ -82,13 +82,13 @@ def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monke
         lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc, command)),
     )
     monkeypatch.setattr(core, "set_metadata", lambda *args: metadata_calls.append(args))
-    monkeypatch.setattr(core, "send_keys", lambda session_name, text: send_calls.append((session_name, text)))
-
-    def fake_wait(name: str, *, timeout: float, interval: float = 0.25):
-        wait_calls.append((name, timeout, interval))
-        return {"type": "pi", "state": "idle", "ready": True}
-
-    monkeypatch.setattr(core, "wait_until_session_ready", fake_wait)
+    monkeypatch.setattr(
+        core,
+        "launch_agent_session",
+        lambda session_name, command, *, prompt=None, expected_cwd=None, prompt_timeout=30.0: launch_calls.append(
+            (session_name, command, prompt, expected_cwd, prompt_timeout)
+        ),
+    )
 
     result = core.create_profile_session(
         "review-wilson",
@@ -102,7 +102,7 @@ def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monke
             "review-wilson",
             str(worktree_dir),
             "Review Wilson",
-            f"pi --session-dir {worktree_dir}/.tmux-pilot/pi/sessions",
+            None,
         )
     ]
     assert metadata_calls == [
@@ -112,8 +112,15 @@ def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monke
         ("review-wilson", "status", "active"),
         ("review-wilson", "desc", "Review Wilson"),
     ]
-    assert send_calls == [("review-wilson", "Summarize the issue and propose a fix.")]
-    assert wait_calls == [("review-wilson", 12.0, 0.25)]
+    assert launch_calls == [
+        (
+            "review-wilson",
+            f"pi --session-dir {worktree_dir}/.tmux-pilot/pi/sessions",
+            "Summarize the issue and propose a fix.",
+            str(worktree_dir),
+            12.0,
+        ),
+    ]
     assert result["branch"] == "fix/771-review-wilson"
     assert result["worktree"] == str(worktree_dir)
 
@@ -124,7 +131,7 @@ def test_create_profile_session_launches_agent_in_directory_without_bootstrap(mo
         command=("codex", "--profile", "yolo"),
     )
     metadata_calls: list[tuple[str, str, str]] = []
-    send_calls: list[tuple[str, str]] = []
+    launch_calls: list[tuple[str, str, str | None, str | None, float]] = []
     new_calls: list[tuple[str, str | None, str | None, str | None]] = []
 
     monkeypatch.setattr(core, "resolve_session_profile", lambda *args, **kwargs: profile)
@@ -134,7 +141,13 @@ def test_create_profile_session_launches_agent_in_directory_without_bootstrap(mo
         lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc, command)),
     )
     monkeypatch.setattr(core, "set_metadata", lambda *args: metadata_calls.append(args))
-    monkeypatch.setattr(core, "send_keys", lambda session_name, text: send_calls.append((session_name, text)))
+    monkeypatch.setattr(
+        core,
+        "launch_agent_session",
+        lambda session_name, command, *, prompt=None, expected_cwd=None, prompt_timeout=30.0: launch_calls.append(
+            (session_name, command, prompt, expected_cwd, prompt_timeout)
+        ),
+    )
     monkeypatch.setattr(core, "_git_root", lambda path: "")
     monkeypatch.setattr(core, "_detect_git_branch", lambda path: "")
 
@@ -144,12 +157,12 @@ def test_create_profile_session_launches_agent_in_directory_without_bootstrap(mo
         directory=str(tmp_path),
     )
 
-    assert new_calls == [("local-task", str(tmp_path.resolve()), None, "codex --profile yolo")]
+    assert new_calls == [("local-task", str(tmp_path.resolve()), None, None)]
     assert metadata_calls == [
         ("local-task", "task", "local-task"),
         ("local-task", "status", "active"),
     ]
-    assert send_calls == []
+    assert launch_calls == [("local-task", "codex --profile yolo", None, str(tmp_path.resolve()), 10.0)]
     assert result["worktree"] == str(tmp_path.resolve())
 
 

--- a/tests/test_send_keys_tmux.py
+++ b/tests/test_send_keys_tmux.py
@@ -292,6 +292,9 @@ def test_cli_new_bootstraps_worktree_and_launches_real_pi(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    if shutil.which("pi") is None:
+        pytest.skip("pi is required for Pi integration tests")
+
     repo = tmp_path / "repo"
     repo.mkdir()
     init_git_repo(repo)

--- a/tests/test_send_keys_tmux.py
+++ b/tests/test_send_keys_tmux.py
@@ -152,6 +152,44 @@ def launch_mock_claude(session_name: str, workdir: Path) -> None:
     wait_for_output(session_name, "Claude Code mock")
 
 
+def launch_real_pi(session_name: str, workdir: Path, session_dir: Path) -> None:
+    if shutil.which("pi") is None:
+        pytest.skip("pi is required for Pi integration tests")
+
+    command = " ".join(
+        [
+            "PI_OFFLINE=1",
+            "pi",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--session-dir",
+            shlex.quote(str(session_dir)),
+        ]
+    )
+    core._run(
+        ["tmux", "new-session", "-d", "-s", session_name, "-c", str(workdir), command],
+        check=True,
+    )
+    wait_for_output(session_name, "pi v", timeout=8.0)
+
+
+def init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.name", "tmux-pilot"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tmux-pilot@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=path, check=True, capture_output=True, text=True)
+
+
 def test_real_tmux_mock_codex_requires_extra_enter_without_settle_delay(real_tmux: RealTmuxServer, tmp_path: Path):
     session = "mock-codex-no-delay"
     launch_mock_codex(session, tmp_path)
@@ -236,3 +274,58 @@ def test_cli_send_wait_uses_claude_transcript_state_with_real_tmux(
     wait_for(first.exists, timeout=3.0, message="timed out waiting for first.txt")
     wait_for(second.exists, timeout=3.0, message="timed out waiting for second.txt")
     wait_for(lambda: second.read_text() == "beta\n", timeout=3.0, message="timed out waiting for second.txt contents")
+
+
+def test_get_session_status_detects_real_pi(real_tmux: RealTmuxServer, tmp_path: Path):
+    session = "real-pi-status"
+    launch_real_pi(session, tmp_path, tmp_path / "pi-sessions")
+
+    status = core.get_session_status(session)
+
+    assert status["process"] == "pi"
+    assert status["agent"]["type"] == "pi"
+    assert status["agent"]["ready"] is True
+
+
+def test_cli_new_bootstraps_worktree_and_launches_real_pi(
+    real_tmux: RealTmuxServer,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_git_repo(repo)
+
+    config = tmp_path / "profiles.toml"
+    worktrees = tmp_path / "worktrees"
+    config.write_text(
+        f"""
+[profiles.pi]
+worktree_base = "{worktrees}"
+branch_prefix = "task"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "PROFILE_CONFIG_PATH", config)
+
+    session = "pi-task"
+    cli_main(["new", session, "--profile", "pi", "--repo", str(repo)])
+
+    expected_worktree = worktrees / f"{repo.name}-{session}"
+    wait_for_output(session, "pi v", timeout=8.0)
+
+    status = core.get_session_status(session)
+
+    assert status["working_dir"] == str(expected_worktree)
+    assert status["process"] == "pi"
+    assert status["agent"]["type"] == "pi"
+    assert status["metadata"]["branch"] == "task/pi-task"
+    assert subprocess.run(
+        ["git", "-C", str(expected_worktree), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == "task/pi-task"
+
+    core.send_keys(session, "/name tmux-pilot-pi")
+    wait_for_output(session, "Session name set: tmux-pilot-pi", timeout=5.0)


### PR DESCRIPTION
## Summary
- add reusable `tp new` profiles with built-in `codex`, `claude`, and `pi` defaults
- make profile behavior configurable via `~/.config/tmux-pilot/profiles.toml`, including inheritance, repo defaults, branch defaults, and templated command/env values
- extend `tp new` so it can resolve or clone a repo, derive or create a task branch, create a git worktree, and launch the selected agent inside that worktree
- add Pi support end-to-end, including reliable direct tmux startup, Pi transcript/state detection, and real tmux-backed tests for the new/session flow
- update the README and how-to docs with copy-paste CLI examples instead of abstract descriptions

## Concrete Profile Examples
These are the built-in profile behaviors now shipped by `tp new`:

```bash
# Launch Codex in an existing checkout
# Runs: codex --profile yolo
tp new auth-pass --profile codex -c ~/repos/myapp

# Launch Claude Code in an existing checkout
# Runs: claude --permission-mode bypassPermissions
tp new review-pass --profile claude -c ~/repos/myapp

# Launch Pi in an existing checkout
# Runs: pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
tp new pi-local --profile pi -c ~/repos/pi-mono
```

Built-in profiles:
- `codex` -> `codex --profile yolo`
- `claude` -> `claude --permission-mode bypassPermissions`
- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`

## Concrete Task / Worktree Bootstrap Examples
`tp new` now handles repo bootstrap directly instead of requiring a separate manual prep step.

```bash
# Local repo bootstrap
# Derives branch: feat/oauth-fix
# Creates worktree: ~/worktrees/myapp-oauth-fix
# Launches: codex --profile yolo
tp new oauth-fix --profile codex --repo ~/repos/myapp

# Issue-driven branch/bootstrap
# Derives branch: fix/771-issue-771
# Fetches the issue title into @desc
# Launches: claude --permission-mode bypassPermissions
tp new issue-771 --profile claude --repo ~/repos/myapp --issue 771

# GitHub bootstrap
# Clones to ~/repos/pi-mono if missing
# Creates worktree: ~/worktrees/pi-mono-pi-smoke
# Derives branch: feat/pi-smoke
# Launches: pi --session-dir ~/worktrees/pi-mono-pi-smoke/.tmux-pilot/pi/sessions
tp new pi-smoke --profile pi --repo badlogic/pi-mono

# Explicit branch/base override
tp new cleanup --profile codex --repo ~/repos/myapp --branch chore/cleanup
tp new backport --profile codex --repo ~/repos/myapp --base-ref origin/release/1.2
```

Accepted `--repo` inputs:
- local path, e.g. `~/repos/myapp`
- GitHub slug, e.g. `badlogic/pi-mono`
- GitHub URL, e.g. `https://github.com/badlogic/pi-mono.git`

## Configurable Profile Example
Example config:

```toml
[default]
extends = "codex"
worktree_base = "~/worktrees"
clone_base = "~/repos"

[profiles.pi]
extends = "pi"
branch_prefix = "task"

[profiles.myapp]
extends = "codex"
repo = "~/repos/myapp"
branch_prefix = "feat"
base_ref = "origin/main"
```

What that enables:

```bash
# Uses [default], so this still launches codex --profile yolo
# even without --profile
tp new rename-types -c ~/repos/myapp

# Uses repo/base_ref from [profiles.myapp]
tp new api-cleanup --profile myapp

# Uses the customized Pi branch prefix, so the branch is task/pi-smoke
tp new pi-smoke --profile pi --repo badlogic/pi-mono
```

## Why
Before this change, `tp new` required manual repo/worktree setup and the profile story was too ad hoc. This makes the CLI coherent around one task-start command and makes Codex, Claude Code, and Pi launch behavior explicit and reusable.

## Issue linkage
Relates to #12 and #15.

Partially addresses #5 and #6.

More specifically:
- #15: adds worktree-aware `tp new` flows, stronger cwd guarantees, and post-launch cwd verification
- #12: adds file-backed transcript/session state for supported agents and uses it to improve `tp send --wait`
- #5: improves prompt delivery reliability, but does not fully guarantee delivery in every interactive-agent state
- #6: improves readiness detection and reduces blind polling, but does not yet provide a first-class completion event model

Issue #7 remains open and is not fully addressed here.

## Validation
- `uv run ruff check`
- `uv run pytest -q` (`98 passed`)
- exercised real Pi startup/status behavior in tmux-backed tests, including worktree bootstrap flow