### PR TITLE
[codex] Add PR refresh and dashboard metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tmux-pilot
 
-A thin, opinionated CLI for managing tmux sessions that run AI coding agents (Claude Code, Codex, etc).
+A thin, opinionated CLI for managing tmux sessions, task worktrees, and PR metadata for AI coding agents (Claude Code, Codex, etc).
 
-**Why?** When you run multiple AI coding agents in parallel — each in its own tmux session — you need a way to list them, peek at their output, send follow-up instructions, and track metadata like status and branch. `tmux-pilot` wraps the fiddly tmux commands into a single `tp` command designed for both humans and AI orchestrators.
+**Why?** When you run multiple AI coding agents in parallel — each in its own tmux session and often each in its own git worktree — you need a way to bootstrap task branches, list active sessions, peek at output, send follow-up instructions, refresh PR state, and clean up once the branch lands. `tmux-pilot` wraps the fiddly tmux and git conventions into a single `tp` command designed for both humans and AI orchestrators.
 
 ## Install
 
@@ -31,7 +31,7 @@ tp new auth-flow --profile codex -c ~/repos/myapp
 tp new review-pass --profile claude -c ~/repos/myapp
 
 # Start Pi in an existing checkout.
-# tmux-pilot runs: pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
+# tmux-pilot runs: pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
 tp new pi-local --profile pi -c ~/repos/pi-mono
 
 # Bootstrap a task branch + worktree from a local repo, then launch Codex there.
@@ -45,6 +45,10 @@ tp new pi-smoke --profile pi --repo badlogic/pi-mono
 
 # Check on all your sessions
 tp ls
+
+# Refresh PR/review metadata, then show a compact dashboard
+tp refresh --repo myapp
+tp ls --cols NAME,PR,STATUS,DIR
 
 # Peek at output without attaching
 tp peek auth-flow -n 30
@@ -84,8 +88,24 @@ tp ls --json                   # JSON output (for AI orchestrators)
 tp ls --status active          # filter by @status metadata
 tp ls --repo myapp             # filter by repo (substring match)
 tp ls --process claude-code    # filter by detected process
+tp ls --all-metadata           # append known metadata columns
+tp ls --cols NAME,PR,DIR       # compact PR dashboard
 tp ls --json --status active   # combine filters with JSON
 ```
+
+`PR` is a compact summary column. It starts with the PR number, then appends short review/merge codes when available:
+
+- `M`: merged
+- `X`: closed
+- `A`: approved
+- `CR`: changes requested
+- `RR`: review required
+- `P`: pending review state
+- `D`: dirty/conflicted
+- `B`: blocked
+- `C`: clean
+
+Examples: `1548 RR D`, `1553 CR`, `1547 M`.
 
 ### `tp new` — Create a session
 
@@ -123,7 +143,7 @@ tp new auth-pass --profile codex -c ~/repos/myapp
 # Launches `claude --permission-mode bypassPermissions` in ~/repos/myapp
 tp new review-pass --profile claude -c ~/repos/myapp
 
-# Launches `pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
+# Launches `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
 tp new pi-local --profile pi -c ~/repos/pi-mono
 ```
 
@@ -159,7 +179,7 @@ Built-in launch profiles:
 
 - `codex`: `codex --profile yolo`
 - `claude`: `claude --permission-mode bypassPermissions`
-- `pi`: `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+- `pi`: `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions`
 
 Recommended profile config lives at `~/.config/tmux-pilot/profiles.toml`:
 
@@ -225,15 +245,37 @@ tp jump                        # fzf picker (requires fzf)
 
 ### `tp status` — Detailed session info
 
-Shows process, PID, working directory, all metadata, and the last 5 lines of scrollback.
+Shows process, PID, working directory, all metadata, relative freshness for cached metadata, and the last 5 lines of scrollback.
 
 ```bash
 tp status NAME
 ```
 
+PR-related metadata is shown with refresh ages when available, for example:
+
+```text
+@pr = 1548 (updated 2m ago)
+@pr_review = REVIEW_REQUIRED (updated 2m ago)
+@pr_merge_state = DIRTY (updated 2m ago)
+@last_refresh = 2026-04-19T22:39:42.658Z
+```
+
+### `tp refresh` — Refresh PR metadata without reaping
+
+Use this when you want a review dashboard or fresh PR metadata without any destructive cleanup.
+
+```bash
+tp refresh                      # all sessions
+tp refresh docs-pass            # one named session
+tp refresh --repo myapp         # repo-scoped subset
+tp refresh --json               # machine-readable output
+```
+
+`tp refresh` updates `@pr`, `@pr_state`, `@pr_review`, `@pr_merge_state`, and `@last_refresh` in tmux metadata. It does not kill sessions, remove worktrees, or delete branches.
+
 ### `tp set` / `tp get` — Session metadata
 
-Metadata is stored as tmux user options (`@`-prefixed). Common built-in keys include `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, and `last_send`.
+Metadata is stored as tmux user options (`@`-prefixed). Common built-in keys include `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, `last_send`, `pr`, `pr_state`, `pr_review`, `pr_merge_state`, and `last_refresh`.
 
 ```bash
 tp set NAME status "waiting-for-review"
@@ -264,12 +306,16 @@ $ tp ls --json
 A typical orchestrator loop:
 
 ```bash
-# Poll for sessions needing attention
-tp ls --json --status needs-review | jq '.[].name' | while read name; do
+# Refresh review state for a repo
+tp refresh --repo myapp
+
+# See which branches need attention
+tp ls --cols NAME,PR,STATUS,DIR --repo myapp
+
+# Drill into the sessions that need work
+tp ls --json --repo myapp | jq -r '.[] | select(.metadata.pr_review == "CHANGES_REQUESTED") | .name' | while read name; do
   tp peek "$name" -n 20
-  # ... decide what to do ...
-  tp send "$name" "next instruction"
-  tp set "$name" status active
+  tp send --wait "$name" "address the requested review changes"
 done
 ```
 
@@ -277,10 +323,13 @@ done
 
 - **Zero dependencies** — stdlib only (subprocess calls to tmux)
 - **Process detection** — distinguishes claude-code vs codex vs bare shell
-- **Metadata** — tmux user options (@status, @desc, @repo, @branch, etc.)
+- **Task bootstrap** — create task branches and worktrees directly from `tp new --repo`
+- **PR refresh** — cache PR number, state, review state, and merge state with `tp refresh`
+- **Metadata** — tmux user options (@status, @desc, @repo, @branch, @pr, etc.)
+- **Metadata freshness** — `tp status` shows when cached fields were last updated
 - **Peek without attaching** — critical for orchestrators monitoring sessions
 - **JSON output** — `tp ls --json` for machine-readable session data
-- **Filtering** — `tp ls --status/--repo/--process` to narrow results
+- **Filtering** — `tp ls --status/--repo/--process` and `tp refresh --repo` to narrow results
 - **fzf integration** — optional fuzzy picker for `tp jump`
 
 ## License

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -9,11 +9,26 @@ tp ls
 tp ls --status active
 tp ls --process codex
 tp ls --repo tmux-pilot
+tp refresh --repo tmux-pilot
 tp ls --json
+tp ls --all-metadata
 tp ls --cols NAME,STATUS,PROCESS,BRANCH
+tp ls --cols NAME,PR,STATUS,DIR
 ```
 
-Use `--json` when another tool needs structured session data. Use `--cols` when you want a tighter table for terminal work.
+Use `tp refresh` before dashboard-style `tp ls` views when you want current PR metadata. Use `--json` when another tool needs structured session data. Use `--cols` when you want a tighter table for terminal work.
+
+The compact `PR` column combines the PR number with short codes:
+
+- `M` merged
+- `X` closed
+- `A` approved
+- `CR` changes requested
+- `RR` review required
+- `P` pending
+- `D` dirty/conflicted
+- `B` blocked
+- `C` clean
 
 ## Start Sessions In Place
 
@@ -111,6 +126,18 @@ tp get docs-pass branch
 
 Built-in metadata is also surfaced through `tp status` and `tp ls --json`.
 
+## Refresh PR Metadata And Build A Review Dashboard
+
+```bash
+tp refresh
+tp refresh --repo myapp
+tp ls --cols NAME,PR,STATUS,DIR --repo myapp
+tp ls --all-metadata --repo myapp
+tp status docs-pass
+```
+
+Use this when `tp` is acting as the orchestration dashboard for many task worktrees. `tp status` shows the cached PR fields with relative freshness, and `tp ls --all-metadata` exposes the raw `PR_NUM`, `PR_STATE`, `REVIEW`, `MERGE_STATE`, and `LAST_REFRESH` columns when you need full detail.
+
 ## Clean Up Sessions And Worktrees
 
 ### Kill one session immediately
@@ -161,6 +188,12 @@ Use this when you want git lifecycle hooks wired to `tp`'s session cleanup flows
 ```bash
 # Start the task in a worktree
 tp new oauth-fix --profile codex --repo ~/repos/myapp
+
+# Refresh review and merge state across the repo
+tp refresh --repo myapp
+
+# See the compact dashboard
+tp ls --cols NAME,PR,STATUS,DIR --repo myapp
 
 # Check progress without attaching
 tp peek oauth-fix -n 40

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ Exact built-in launch commands:
 
 - `codex` -> `codex --profile yolo`
 - `claude` -> `claude --permission-mode bypassPermissions`
-- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+- `pi` -> `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions`
 
 ### 3. Bootstrap a task branch and worktree
 
@@ -104,12 +104,17 @@ What happens on the bootstrap path:
 ```bash
 tp ls
 tp ls --status active
+tp refresh --repo tmux-pilot
+tp ls --cols NAME,PR,STATUS,DIR --repo tmux-pilot
+tp ls --all-metadata --repo tmux-pilot
 tp peek docs-pass -n 60
 tp send --wait docs-pass "continue with the failing tests"
 tp status docs-pass
 tp jump docs-pass
 tp kill docs-pass
 ```
+
+Use `tp refresh` before `tp ls` when you want a current review dashboard. The compact `PR` column folds together the PR number plus short review/merge codes such as `A`, `CR`, `RR`, `D`, and `C`.
 
 ## Minimal Profile Config
 

--- a/docs/how-to/create-sessions.md
+++ b/docs/how-to/create-sessions.md
@@ -6,7 +6,7 @@ Built-in profiles:
 
 - `codex` -> `codex --profile yolo`
 - `claude` -> `claude --permission-mode bypassPermissions`
-- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+- `pi` -> `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions`
 
 ## Create a plain tmux session
 
@@ -71,7 +71,7 @@ Those commands launch:
 
 - `codex --profile yolo`
 - `claude --permission-mode bypassPermissions`
-- `pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
+- `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
 
 ## Create a profile-backed worktree session
 
@@ -87,7 +87,7 @@ Concrete outcomes:
 
 - `tp new auth-fix --profile codex --repo ~/repos/myapp` derives branch `feat/auth-fix`, creates `~/worktrees/myapp-auth-fix`, and launches `codex --profile yolo`.
 - `tp new issue-771 --profile claude --repo ~/repos/myapp --issue 771` derives branch `fix/771-issue-771`, copies the issue title into `@desc`, and launches `claude --permission-mode bypassPermissions`.
-- `tp new pi-smoke --profile pi --repo badlogic/pi-mono` clones `~/repos/pi-mono` first if needed, creates `~/worktrees/pi-mono-pi-smoke`, and launches `pi --session-dir ~/worktrees/pi-mono-pi-smoke/.tmux-pilot/pi/sessions`.
+- `tp new pi-smoke --profile pi --repo badlogic/pi-mono` clones `~/repos/pi-mono` first if needed, creates `~/worktrees/pi-mono-pi-smoke`, and launches `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/worktrees/pi-mono-pi-smoke/.tmux-pilot/pi/sessions`.
 
 ## Override the profile's agent
 

--- a/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
+++ b/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
@@ -13,7 +13,7 @@ tp new docs-pass --profile codex -c ~/repos/tmux-pilot
 # Runs: claude --permission-mode bypassPermissions
 tp new review-pass --profile claude -c ~/repos/myapp
 
-# Runs: pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
+# Runs: pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions
 tp new pi-local --profile pi -c ~/repos/pi-mono
 ```
 
@@ -21,7 +21,7 @@ Built-in profiles:
 
 - `codex` -> `codex --profile yolo`
 - `claude` -> `claude --permission-mode bypassPermissions`
-- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+- `pi` -> `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions`
 
 ## Bootstrap A Task Repo
 
@@ -57,7 +57,7 @@ tp new pi-smoke --profile pi --repo badlogic/pi-mono
 If `~/repos/pi-mono` does not exist yet, `tp` clones it first. Then it creates worktree `~/worktrees/pi-mono-pi-smoke`, derives branch `feat/pi-smoke`, and launches:
 
 ```bash
-pi --session-dir ~/worktrees/pi-mono-pi-smoke/.tmux-pilot/pi/sessions
+pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/worktrees/pi-mono-pi-smoke/.tmux-pilot/pi/sessions
 ```
 
 Override the branch or base ref when needed:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hide:
 
 # Run Codex, Claude Code, and Pi in tmux without losing the thread.
 
-`tmux-pilot` gives you one operational CLI for starting agent sessions, bootstrapping task worktrees, peeking at live output, sending follow-up instructions, and cleaning up after the branch lands.
+`tmux-pilot` gives you one operational CLI for starting agent sessions, bootstrapping task worktrees, refreshing PR state, steering live agents, and cleaning up after the branch lands.
 
 <div class="hero-actions" markdown="1">
 
@@ -41,10 +41,11 @@ tp new auth-fix --profile claude --repo ~/repos/myapp --issue 771
 </div>
 
 <div class="command-tile" markdown="1">
-<span class="command-label">Send the next instruction safely</span>
+<span class="command-label">Refresh a repo dashboard</span>
 
 ```bash
-tp send --wait docs-pass "add tests for the OAuth callback"
+tp refresh --repo myapp
+tp ls --cols NAME,PR,STATUS,DIR --repo myapp
 ```
 
 </div>
@@ -72,6 +73,8 @@ tp send --wait docs-pass "add tests for the OAuth callback"
 === "Steer a long-lived session"
 
     ```bash
+    tp refresh --repo myapp
+    tp ls --cols NAME,PR,STATUS,DIR --repo myapp
     tp ls --status active
     tp peek docs-pass -n 50
     tp send --wait docs-pass "continue with regression coverage"
@@ -96,7 +99,7 @@ tp send --wait docs-pass "add tests for the OAuth callback"
 
 -   **Steering without attaching**
 
-    `tp ls`, `tp peek`, `tp send --wait`, and `tp status` let you manage live sessions from another terminal.
+    `tp refresh`, `tp ls`, `tp peek`, `tp send --wait`, and `tp status` let you manage live sessions from another terminal.
 
 </div>
 
@@ -110,7 +113,7 @@ tp send --wait docs-pass "add tests for the OAuth callback"
 
 -   **[CLI Cookbook](cli-cookbook.md)**
 
-    Find copy-paste examples for common flows: listing sessions, sending follow-ups, bootstrapping worktrees, cleaning up, and reaping merged branches.
+    Find copy-paste examples for common flows: listing sessions, refreshing PR dashboards, sending follow-ups, bootstrapping worktrees, cleaning up, and reaping merged branches.
 
 -   **[Profiles and Worktrees](how-to/start-task-sessions-with-profiles-and-worktrees.md)**
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -16,6 +16,7 @@ This page is the compact command reference for `tp`. For longer walkthroughs, us
 | `tp kill` | kill a session immediately |
 | `tp set` / `tp get` | manage tmux-backed session metadata |
 | `tp install-hooks` | install or remove git lifecycle hooks |
+| `tp refresh` | refresh cached PR metadata without cleanup |
 | `tp reap` | remove sessions whose PRs are merged |
 
 ## `tp ls`
@@ -25,9 +26,23 @@ tp ls
 tp ls --status active
 tp ls --process claude-code
 tp ls --repo myapp
+tp ls --all-metadata
 tp ls --cols NAME,STATUS,PROCESS,BRANCH
+tp ls --cols NAME,PR,STATUS,DIR
 tp ls --json
 ```
+
+`PR` is a compact summary column. It starts with the PR number and appends short codes when available:
+
+- `M` merged
+- `X` closed
+- `A` approved
+- `CR` changes requested
+- `RR` review required
+- `P` pending
+- `D` dirty/conflicted
+- `B` blocked
+- `C` clean
 
 ## `tp new`
 
@@ -35,7 +50,7 @@ Built-in profiles:
 
 - `codex` -> `codex --profile yolo`
 - `claude` -> `claude --permission-mode bypassPermissions`
-- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+- `pi` -> `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions`
 
 ### Plain sessions
 
@@ -55,7 +70,7 @@ tp new docs-pass --profile codex -c ~/repos/tmux-pilot
 # Starts `claude --permission-mode bypassPermissions` in ~/repos/myapp
 tp new review-pass --profile claude -c ~/repos/myapp
 
-# Starts `pi --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
+# Starts `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir ~/repos/pi-mono/.tmux-pilot/pi/sessions`
 tp new pi-local --profile pi -c ~/repos/pi-mono
 ```
 
@@ -116,6 +131,7 @@ tp status docs-pass
 - detected process
 - working directory
 - tmux metadata
+- metadata freshness for cached fields such as PR state
 - current agent state
 - recent scrollback
 
@@ -150,6 +166,17 @@ tp install-hooks --path ~/.config/git/hooks
 tp install-hooks --uninstall
 ```
 
+## `tp refresh`
+
+```bash
+tp refresh
+tp refresh docs-pass
+tp refresh --repo myapp
+tp refresh --json
+```
+
+`tp refresh` updates cached PR metadata only. It writes `@pr`, `@pr_state`, `@pr_review`, `@pr_merge_state`, and `@last_refresh`, but it does not kill sessions, remove worktrees, or delete branches.
+
 ## `tp reap`
 
 ```bash
@@ -157,6 +184,8 @@ tp reap --dry-run
 tp reap --force
 tp reap --include-no-pr --dry-run
 ```
+
+`tp reap --dry-run` still refreshes and persists safe PR metadata before deciding what would be reaped.
 
 ## Notes On Current Behavior
 

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -88,6 +88,15 @@ result = reaper.reap_sessions(dry_run=True)
 print(result)
 ```
 
+## Refresh Cached PR Metadata
+
+```python
+from tmux_pilot import reaper
+
+result = reaper.refresh_pr_metadata(repo="myapp")
+print(result)
+```
+
 ## Recommendation
 
 If the workflow needs to survive shell boundaries, CI jobs, or multiple languages, prefer the CLI:

--- a/docs/reference/session-creation.md
+++ b/docs/reference/session-creation.md
@@ -6,7 +6,7 @@ Built-in profile shortcuts:
 
 - `codex` -> `codex --profile yolo`
 - `claude` -> `claude --permission-mode bypassPermissions`
-- `pi` -> `pi --session-dir {worktree}/.tmux-pilot/pi/sessions`
+- `pi` -> `pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions`
 
 ## Plain Mode
 

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -26,7 +26,7 @@ command, and send an initial prompt once the agent becomes ready.
 Built-in profiles:
   codex  -> codex --profile yolo
   claude -> claude --permission-mode bypassPermissions
-  pi     -> pi --session-dir {worktree}/.tmux-pilot/pi/sessions
+  pi     -> pi --offline --no-extensions --no-skills --no-prompt-templates --no-themes --session-dir {worktree}/.tmux-pilot/pi/sessions
 """
 
 
@@ -67,9 +67,9 @@ def cmd_ls(args: argparse.Namespace) -> None:
     if args.json:
         print(json.dumps([s.to_dict() for s in sessions], indent=2))
     elif args.fzf:
-        print(display.format_fzf(sessions, cols=args.cols))
+        print(display.format_fzf(sessions, cols=args.cols, all_metadata=args.all_metadata))
     else:
-        print(display.format_session_table(sessions, cols=args.cols))
+        print(display.format_session_table(sessions, cols=args.cols, all_metadata=args.all_metadata))
 
 
 def cmd_new(args: argparse.Namespace) -> None:
@@ -329,6 +329,39 @@ def cmd_reap(args: argparse.Namespace) -> None:
     print(f"Reaped {reaped} session(s).")
 
 
+def cmd_refresh(args: argparse.Namespace) -> None:
+    from . import reaper
+
+    try:
+        results = reaper.refresh_pr_metadata(names=args.names or None, repo=args.repo)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return
+
+    if not results:
+        print("No sessions to refresh.")
+        return
+
+    for result in results:
+        if result.get("reason") == "no-branch":
+            print(f"{result['session']}  skipped (no-branch)")
+            continue
+
+        pr = result.get("pr")
+        pr_display = f"#{pr}" if pr is not None else "-"
+        state = result.get("pr_state") or "-"
+        review = result.get("pr_review") or "-"
+        merge_state = result.get("pr_merge_state") or "-"
+        print(
+            f"{result['session']}  branch={result.get('branch', '-') or '-'}"
+            f"  pr={pr_display}  state={state}  review={review}  merge={merge_state}"
+        )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tp",
@@ -349,6 +382,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ls.add_argument("--status", help="Filter by status (e.g. active, done)")
     p_ls.add_argument("--repo", help="Filter by repo name (substring match)")
     p_ls.add_argument("--process", help="Filter by process (e.g. claude-code, python)")
+    p_ls.add_argument("--all-metadata", action="store_true", help="Append all known metadata columns")
 
     # new
     p_new = sub.add_parser(
@@ -440,6 +474,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_reap.add_argument("--force", action="store_true", help="Skip confirmation prompt")
     p_reap.add_argument("--include-no-pr", action="store_true", help="Also flag clean sessions with no PR")
 
+    # refresh
+    p_refresh = sub.add_parser("refresh", help="Refresh cached PR metadata")
+    p_refresh.add_argument("names", nargs="*", help="Optional session names to refresh")
+    p_refresh.add_argument("--repo", help="Filter by repo name (substring match)")
+    p_refresh.add_argument("--json", action="store_true", help="Output refreshed state as JSON")
+
     return parser
 
 
@@ -469,6 +509,7 @@ def main(argv: list[str] | None = None) -> None:
         "get": cmd_get,
         "install-hooks": cmd_install_hooks,
         "reap": cmd_reap,
+        "refresh": cmd_refresh,
     }
     handlers[args.command](args)
 

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -30,6 +30,9 @@ METADATA_KEYS = (
     "last_send",
     "pr",
     "pr_state",
+    "pr_review",
+    "pr_merge_state",
+    "last_refresh",
     "pushing",
 )
 
@@ -70,7 +73,16 @@ _BUILTIN_PROFILE_DEFS: dict[str, dict[str, object]] = {
         "prompt_wait_timeout": 10.0,
     },
     "pi": {
-        "command": ["pi", "--session-dir", _PI_SESSION_DIR_TEMPLATE],
+        "command": [
+            "pi",
+            "--offline",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--session-dir",
+            _PI_SESSION_DIR_TEMPLATE,
+        ],
         "prompt_wait_timeout": 5.0,
     },
 }
@@ -323,14 +335,32 @@ def get_metadata(session_name: str, key: str) -> str:
     return _tmux("display-message", "-t", session_name, "-p", f"#{{@{key}}}", check=False)
 
 
-def set_metadata(session_name: str, key: str, value: str) -> None:
-    """Set a @metadata value on a session."""
+def _set_metadata_option(session_name: str, key: str, value: str) -> None:
+    """Set a single tmux @option value without touching companion timestamps."""
     _tmux("set-option", "-t", session_name, f"@{key}", value)
+
+
+def set_metadata(session_name: str, key: str, value: str) -> None:
+    """Set a @metadata value on a session and record when it changed."""
+    _set_metadata_option(session_name, key, value)
+    if key.endswith("_updated_at"):
+        return
+    _set_metadata_option(session_name, f"{key}_updated_at", _metadata_timestamp())
 
 
 def _metadata_timestamp() -> str:
     """Return a UTC timestamp suitable for sortable tmux metadata."""
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _get_metadata_updated_at(session_name: str, keys: list[str]) -> dict[str, str]:
+    """Fetch companion @<key>_updated_at timestamps for the given metadata keys."""
+    timestamps: dict[str, str] = {}
+    for key in keys:
+        value = get_metadata(session_name, f"{key}_updated_at")
+        if value:
+            timestamps[key] = value
+    return timestamps
 
 
 def new_session(
@@ -1350,6 +1380,7 @@ def get_session_status(name: str) -> dict:
         raise RuntimeError(f"Session '{name}' not found")
 
     pane_cmd, pane_path, pane_pid, meta = _session_pane_details(name)
+    metadata_updated_at = _get_metadata_updated_at(name, list(meta))
     scrollback = peek_session(name, lines=5)
     agent = _get_agent_state(
         name,
@@ -1363,6 +1394,7 @@ def get_session_status(name: str) -> dict:
         "pid": pane_pid,
         "working_dir": pane_path,
         "metadata": meta,
+        "metadata_updated_at": metadata_updated_at,
         "scrollback_tail": scrollback,
         "agent": agent,
     }

--- a/src/tmux_pilot/display.py
+++ b/src/tmux_pilot/display.py
@@ -3,10 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime, timezone
 
 from .core import SessionInfo
 
 ColumnAccessor = Callable[[SessionInfo], str]
+_PR_REFRESH_KEYS = {"pr", "pr_state", "pr_review", "pr_merge_state"}
+_ALL_METADATA_COLUMN_NAMES = [
+    "STATUS",
+    "DESC",
+    "REPO",
+    "TASK",
+    "BRANCH",
+    "ORIGIN",
+    "NEEDS",
+    "LAST_COMMIT",
+    "LAST_SEND",
+    "PR_NUM",
+    "PR_STATE",
+    "REVIEW",
+    "MERGE_STATE",
+    "LAST_REFRESH",
+    "PUSHING",
+]
 
 # All available columns: (long_name, mnemonic, accessor)
 ALL_COLUMNS: list[tuple[str, str, ColumnAccessor]] = [
@@ -19,14 +38,23 @@ ALL_COLUMNS: list[tuple[str, str, ColumnAccessor]] = [
     ("REPO", "R", lambda s: _shorten_path(s.metadata.get("repo", "")) or "-"),
     ("TASK", "T", lambda s: s.metadata.get("task", "") or "-"),
     ("BRANCH", "B", lambda s: s.metadata.get("branch", "") or "-"),
-    ("PR", "G", lambda s: s.metadata.get("pr", "") or "-"),
+    ("PR", "G", lambda s: _pr_summary(s.metadata)),
+    ("PR_NUM", "J", lambda s: s.metadata.get("pr", "") or "-"),
     ("PR_STATE", "X", lambda s: s.metadata.get("pr_state", "") or "-"),
+    ("REVIEW", "V", lambda s: s.metadata.get("pr_review", "") or "-"),
+    ("MERGE_STATE", "M", lambda s: s.metadata.get("pr_merge_state", "") or "-"),
+    ("ORIGIN", "O", lambda s: s.metadata.get("origin", "") or "-"),
+    ("NEEDS", "E", lambda s: s.metadata.get("needs", "") or "-"),
+    ("LAST_COMMIT", "K", lambda s: s.metadata.get("last_commit", "") or "-"),
+    ("LAST_SEND", "L", lambda s: s.metadata.get("last_send", "") or "-"),
+    ("LAST_REFRESH", "F", lambda s: s.metadata.get("last_refresh", "") or "-"),
+    ("PUSHING", "U", lambda s: s.metadata.get("pushing", "") or "-"),
 ]
 
 _COL_BY_MNEMONIC = {m: (name, acc) for name, m, acc in ALL_COLUMNS}
 _COL_BY_NAME = {name: (name, acc) for name, _, acc in ALL_COLUMNS}
 
-DEFAULT_COLS = "NSPADW"
+DEFAULT_COLS = "NAME,STATUS,PROCESS,AGENT_STATE,PR,DIR"
 
 
 def parse_cols(spec: str | None) -> list[tuple[str, ColumnAccessor]]:
@@ -64,12 +92,17 @@ def parse_cols(spec: str | None) -> list[tuple[str, ColumnAccessor]]:
     return result
 
 
-def format_session_table(sessions: list[SessionInfo], cols: str | None = None) -> str:
+def format_session_table(
+    sessions: list[SessionInfo],
+    cols: str | None = None,
+    *,
+    all_metadata: bool = False,
+) -> str:
     """Format sessions as an aligned table with configurable columns."""
     if not sessions:
         return "No tmux sessions found."
 
-    columns = parse_cols(cols)
+    columns = _resolve_columns(cols, all_metadata=all_metadata)
     headers = [name for name, _ in columns]
     accessors = [acc for _, acc in columns]
     rows = [[acc(s) for acc in accessors] for s in sessions]
@@ -91,7 +124,12 @@ def format_session_table(sessions: list[SessionInfo], cols: str | None = None) -
     return "\n".join(lines)
 
 
-def format_fzf(sessions: list[SessionInfo], cols: str | None = None) -> str:
+def format_fzf(
+    sessions: list[SessionInfo],
+    cols: str | None = None,
+    *,
+    all_metadata: bool = False,
+) -> str:
     """Format sessions as tab-separated lines for fzf piping.
 
     First field is the raw session name (for selection), remaining
@@ -100,7 +138,7 @@ def format_fzf(sessions: list[SessionInfo], cols: str | None = None) -> str:
     if not sessions:
         return ""
 
-    columns = parse_cols(cols)
+    columns = _resolve_columns(cols, all_metadata=all_metadata)
     accessors = [acc for _, acc in columns]
     lines = []
     for s in sessions:
@@ -109,7 +147,7 @@ def format_fzf(sessions: list[SessionInfo], cols: str | None = None) -> str:
     return "\n".join(lines)
 
 
-def format_status(info: dict) -> str:
+def format_status(info: dict, *, now: datetime | None = None) -> str:
     """Format detailed session status."""
     lines = [
         f"Session:  {info['name']}",
@@ -123,11 +161,15 @@ def format_status(info: dict) -> str:
         lines.append(f"Agent:    {agent.get('type', 'unknown')} ({agent.get('state', 'unknown')})")
 
     meta = info.get("metadata", {})
+    meta_updated_at = info.get("metadata_updated_at", {})
     if meta:
         lines.append("")
         lines.append("Metadata:")
         for k, v in sorted(meta.items()):
-            lines.append(f"  @{k} = {v}")
+            if not _show_metadata_row(k, v):
+                continue
+            suffix = _metadata_age_suffix(k, v, meta, meta_updated_at, now=now)
+            lines.append(f"  @{k} = {v}{suffix}")
 
     scrollback = info.get("scrollback_tail", "")
     if scrollback.strip():
@@ -148,3 +190,120 @@ def _shorten_path(path: str) -> str:
     if path.startswith(home):
         return "~" + path[len(home):]
     return path
+
+
+def _resolve_columns(spec: str | None, *, all_metadata: bool = False) -> list[tuple[str, ColumnAccessor]]:
+    columns = parse_cols(spec)
+    if not all_metadata:
+        return columns
+
+    seen = {name for name, _ in columns}
+    for name in _ALL_METADATA_COLUMN_NAMES:
+        if name in seen:
+            continue
+        columns.append(_COL_BY_NAME[name])
+        seen.add(name)
+    return columns
+
+
+def _pr_summary(metadata: dict[str, str]) -> str:
+    pr = metadata.get("pr", "")
+    if not pr:
+        return "-"
+
+    state = metadata.get("pr_state", "")
+    if state == "MERGED":
+        return f"{pr} M"
+    if state == "CLOSED":
+        return f"{pr} X"
+
+    codes: list[str] = []
+
+    review = metadata.get("pr_review", "")
+    if review == "APPROVED":
+        codes.append("A")
+    elif review == "CHANGES_REQUESTED":
+        codes.append("CR")
+    elif review == "REVIEW_REQUIRED":
+        codes.append("RR")
+    elif review == "PENDING":
+        codes.append("P")
+
+    merge_state = metadata.get("pr_merge_state", "")
+    if merge_state == "DIRTY":
+        codes.append("D")
+    elif merge_state == "BLOCKED":
+        codes.append("B")
+    elif merge_state == "CLEAN":
+        codes.append("C")
+
+    if not codes:
+        return pr
+    return f"{pr} {' '.join(codes)}"
+
+
+def _show_metadata_row(key: str, value: str) -> bool:
+    if key == "pr_merge_state" and value == "UNKNOWN":
+        return False
+    return True
+
+
+def _metadata_age_suffix(
+    key: str,
+    value: str,
+    metadata: dict[str, str],
+    metadata_updated_at: dict[str, str],
+    *,
+    now: datetime | None = None,
+) -> str:
+    if _parse_iso_timestamp(value) is not None:
+        return ""
+
+    updated_at = metadata_updated_at.get(key, "")
+    if not updated_at and key in _PR_REFRESH_KEYS:
+        updated_at = metadata.get("last_refresh", "")
+
+    relative = _relative_time(updated_at, now=now)
+    if not relative:
+        return ""
+    return f" (updated {relative})"
+
+
+def _relative_time(value: str, *, now: datetime | None = None) -> str:
+    timestamp = _parse_iso_timestamp(value)
+    if timestamp is None:
+        return ""
+
+    now_utc = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    seconds = max(0, int((now_utc - timestamp).total_seconds()))
+
+    if seconds < 5:
+        return "just now"
+    if seconds < 60:
+        return f"{seconds}s ago"
+
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+
+    days = hours // 24
+    return f"{days}d ago"
+
+
+def _parse_iso_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    normalized = value
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/src/tmux_pilot/reaper.py
+++ b/src/tmux_pilot/reaper.py
@@ -8,22 +8,28 @@ import subprocess
 from . import core
 
 
-def _gh_pr_status(branch: str) -> dict | None:
+def _gh_pr_status(branch: str, *, repo_dir: str = "") -> dict | None:
     """Query GitHub for PR status on a branch.
 
-    Returns dict with 'number' and 'state', or None if no PR found.
+    Returns dict with number/state/review/merge_state, or None if no PR found.
     """
     result = subprocess.run(
         ["gh", "pr", "list", "--head", branch, "--state", "all",
-         "--json", "number,state", "--limit", "1"],
-        capture_output=True, text=True, timeout=15,
+         "--json", "number,state,reviewDecision,mergeStateStatus", "--limit", "1"],
+        capture_output=True, text=True, timeout=15, cwd=repo_dir or None,
     )
     if result.returncode != 0 or not result.stdout.strip():
         return None
     prs = json.loads(result.stdout)
     if not prs:
         return None
-    return {"number": prs[0]["number"], "state": prs[0]["state"]}
+    pr = prs[0]
+    return {
+        "number": pr["number"],
+        "state": pr["state"],
+        "review": pr.get("reviewDecision") or "PENDING",
+        "merge_state": pr.get("mergeStateStatus") or "UNKNOWN",
+    }
 
 
 def _has_uncommitted(working_dir: str) -> bool:
@@ -33,6 +39,78 @@ def _has_uncommitted(working_dir: str) -> bool:
         capture_output=True, text=True, timeout=5,
     )
     return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _resolve_sessions(
+    names: list[str] | None = None,
+    *,
+    repo: str | None = None,
+) -> list[core.SessionInfo]:
+    """Return all sessions or a named subset, preserving the requested order."""
+    sessions = core.list_sessions(repo=repo)
+    if not names:
+        return sessions
+
+    by_name = {session.name: session for session in sessions}
+    missing = [name for name in names if name not in by_name]
+    if missing:
+        if len(missing) == 1:
+            raise RuntimeError(f"Session '{missing[0]}' not found")
+        formatted = ", ".join(f"'{name}'" for name in missing)
+        raise RuntimeError(f"Sessions not found: {formatted}")
+    return [by_name[name] for name in names]
+
+
+def _refresh_session_pr_metadata(session: core.SessionInfo) -> dict:
+    """Refresh and persist cached PR metadata for a single session."""
+    branch = session.metadata.get("branch", "")
+    repo_dir = session.working_dir or session.metadata.get("repo", "")
+    action: dict = {
+        "session": session.name,
+        "branch": branch,
+        "pr": None,
+        "pr_state": None,
+        "pr_review": None,
+        "pr_merge_state": None,
+        "last_refresh": None,
+        "skipped": False,
+        "reason": "",
+    }
+
+    if not branch:
+        action["skipped"] = True
+        action["reason"] = "no-branch"
+        return action
+
+    pr_info = _gh_pr_status(branch, repo_dir=repo_dir)
+    refreshed_at = core._metadata_timestamp()
+
+    core.set_metadata(session.name, "pr", str(pr_info["number"]) if pr_info else "")
+    core.set_metadata(session.name, "pr_state", pr_info["state"] if pr_info else "")
+    core.set_metadata(session.name, "pr_review", pr_info["review"] if pr_info else "")
+    core.set_metadata(session.name, "pr_merge_state", pr_info["merge_state"] if pr_info else "")
+    core.set_metadata(session.name, "last_refresh", refreshed_at)
+
+    action.update(
+        {
+            "pr": pr_info["number"] if pr_info else None,
+            "pr_state": pr_info["state"] if pr_info else None,
+            "pr_review": pr_info["review"] if pr_info else None,
+            "pr_merge_state": pr_info["merge_state"] if pr_info else None,
+            "last_refresh": refreshed_at,
+            "reason": f"pr-{pr_info['state'].lower()}" if pr_info else "no-pr",
+        }
+    )
+    return action
+
+
+def refresh_pr_metadata(
+    *,
+    names: list[str] | None = None,
+    repo: str | None = None,
+) -> list[dict]:
+    """Refresh cached PR metadata for all sessions or a named subset."""
+    return [_refresh_session_pr_metadata(session) for session in _resolve_sessions(names, repo=repo)]
 
 
 def reap_sessions(
@@ -53,25 +131,21 @@ def reap_sessions(
     results: list[dict] = []
 
     for s in sessions:
-        branch = s.metadata.get("branch", "")
-        if not branch:
+        refresh = _refresh_session_pr_metadata(s)
+        branch = refresh.get("branch", "")
+        if refresh.get("reason") == "no-branch":
             continue
 
         working_dir = s.working_dir
 
-        # Query PR status
-        pr_info = _gh_pr_status(branch)
-
-        # Cache PR info on the session
-        if pr_info and not dry_run:
-            core.set_metadata(s.name, "pr", str(pr_info["number"]))
-            core.set_metadata(s.name, "pr_state", pr_info["state"])
-
         action: dict = {
             "session": s.name,
             "branch": branch,
-            "pr": pr_info["number"] if pr_info else None,
-            "pr_state": pr_info["state"] if pr_info else None,
+            "pr": refresh["pr"],
+            "pr_state": refresh["pr_state"],
+            "pr_review": refresh["pr_review"],
+            "pr_merge_state": refresh["pr_merge_state"],
+            "last_refresh": refresh["last_refresh"],
             "killed": False,
             "worktree_removed": False,
             "branch_deleted": False,
@@ -80,18 +154,18 @@ def reap_sessions(
         }
 
         # Decide whether to reap
-        if pr_info and pr_info["state"] == "MERGED":
+        if refresh["pr_state"] == "MERGED":
             action["reason"] = "pr-merged"
-        elif not pr_info and include_no_pr:
+        elif refresh["pr"] is None and include_no_pr:
             action["reason"] = "no-pr"
         else:
-            if pr_info:
-                action["reason"] = f"pr-{pr_info['state'].lower()}"
+            if refresh["pr"]:
+                action["reason"] = str(refresh["reason"])
             else:
                 action["reason"] = "no-pr"
             action["skipped"] = True
             # Only include in results if it would be actionable
-            if not include_no_pr and not pr_info:
+            if not include_no_pr and refresh["pr"] is None:
                 continue
             results.append(action)
             continue

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,12 +6,13 @@ import json
 import re
 import shlex
 import subprocess
+from datetime import datetime, timezone
 
 import pytest
 
-from tmux_pilot import agent_sessions, core
+from tmux_pilot import agent_sessions, core, reaper
 from tmux_pilot.cli import main as cli_main
-from tmux_pilot.display import format_session_table, parse_cols
+from tmux_pilot.display import format_session_table, format_status, parse_cols
 
 
 TEST_SESSION = "_tp_test_session"
@@ -187,9 +188,12 @@ class FakeTmux:
         }
         for token, value in replacements.items():
             rendered = rendered.replace(token, value)
-        for key in core.METADATA_KEYS:
-            rendered = rendered.replace(f"#{{@{key}}}", str(session["metadata"].get(key, "")))
-        return re.sub(r"#\{@[^}]+\}", "", rendered)
+        rendered = re.sub(
+            r"#\{@([^}]+)\}",
+            lambda match: str(session["metadata"].get(match.group(1), "")),
+            rendered,
+        )
+        return rendered
 
 
 @pytest.fixture
@@ -253,6 +257,8 @@ class TestMetadata:
         core.new_session(TEST_SESSION)
         core.set_metadata(TEST_SESSION, "status", "running")
         assert core.get_metadata(TEST_SESSION, "status") == "running"
+        updated_at = core.get_metadata(TEST_SESSION, "status_updated_at")
+        assert updated_at.endswith("Z")
 
     def test_get_missing_key(self, fake_tmux: FakeTmux):
         core.new_session(TEST_SESSION)
@@ -616,6 +622,80 @@ class TestDisplay:
         assert "BRANCH" in result
         assert "feat/x" in result
 
+    def test_cols_support_review_and_merge_state(self):
+        result = format_session_table(
+            [
+                core.SessionInfo(
+                    name="s1",
+                    metadata={"pr_review": "APPROVED", "pr_merge_state": "CLEAN"},
+                )
+            ],
+            cols="NAME,REVIEW,MERGE_STATE",
+        )
+        assert "REVIEW" in result
+        assert "MERGE_STATE" in result
+        assert "APPROVED" in result
+        assert "CLEAN" in result
+
+    def test_pr_column_compacts_review_and_merge_codes(self):
+        result = format_session_table(
+            [
+                core.SessionInfo(
+                    name="s1",
+                    metadata={
+                        "pr": "1548",
+                        "pr_state": "OPEN",
+                        "pr_review": "REVIEW_REQUIRED",
+                        "pr_merge_state": "DIRTY",
+                    },
+                )
+            ],
+            cols="NAME,PR",
+        )
+        assert "PR" in result
+        assert "1548 RR D" in result
+
+    def test_pr_column_shows_merged_compactly(self):
+        result = format_session_table(
+            [
+                core.SessionInfo(
+                    name="s1",
+                    metadata={
+                        "pr": "1547",
+                        "pr_state": "MERGED",
+                        "pr_review": "APPROVED",
+                        "pr_merge_state": "UNKNOWN",
+                    },
+                )
+            ],
+            cols="NAME,PR",
+        )
+        assert "1547 M" in result
+        assert "UNKNOWN" not in result
+
+    def test_all_metadata_appends_known_metadata_columns(self):
+        result = format_session_table(
+            [
+                core.SessionInfo(
+                    name="s1",
+                    process="codex",
+                    working_dir="/tmp",
+                    metadata={
+                        "status": "active",
+                        "origin": "git-worktree",
+                        "last_refresh": "2026-04-19T22:15:00Z",
+                        "pr_state": "OPEN",
+                    },
+                )
+            ],
+            cols="NAME",
+            all_metadata=True,
+        )
+        assert "ORIGIN" in result
+        assert "LAST_REFRESH" in result
+        assert "PR_STATE" in result
+        assert "git-worktree" in result
+
     def test_cols_all_mnemonics(self):
         result = format_session_table(
             [
@@ -666,6 +746,50 @@ class TestDisplay:
         with pytest.raises(ValueError, match="Unknown column"):
             parse_cols("NAME,BOGUS")
 
+    def test_format_status_shows_metadata_update_ages(self):
+        rendered = format_status(
+            {
+                "name": "alpha",
+                "process": "codex",
+                "pid": "123",
+                "working_dir": "/tmp/alpha",
+                "metadata": {
+                    "status": "active",
+                    "pr": "42",
+                    "last_refresh": "2026-04-19T22:58:00Z",
+                },
+                "metadata_updated_at": {
+                    "status": "2026-04-19T22:00:00Z",
+                },
+                "agent": {},
+            },
+            now=datetime(2026, 4, 19, 23, 0, tzinfo=timezone.utc),
+        )
+
+        assert "@status = active (updated 1h ago)" in rendered
+        assert "@pr = 42 (updated 2m ago)" in rendered
+        assert "@last_refresh = 2026-04-19T22:58:00Z" in rendered
+
+    def test_format_status_hides_unknown_merge_state(self):
+        rendered = format_status(
+            {
+                "name": "alpha",
+                "process": "codex",
+                "pid": "123",
+                "working_dir": "/tmp/alpha",
+                "metadata": {
+                    "pr": "42",
+                    "pr_state": "MERGED",
+                    "pr_merge_state": "UNKNOWN",
+                },
+                "metadata_updated_at": {},
+                "agent": {},
+            }
+        )
+
+        assert "@pr_state = MERGED" in rendered
+        assert "@pr_merge_state" not in rendered
+
 
 class TestCLI:
     def test_help(self, capsys):
@@ -702,6 +826,86 @@ class TestCLI:
         cli_main(["ls", "--json", "--status", "active"])
         data = json.loads(capsys.readouterr().out)
         assert [session["name"] for session in data] == [TEST_SESSION]
+
+    def test_refresh_json(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(
+            reaper,
+            "refresh_pr_metadata",
+            lambda names=None, repo=None: [
+                {
+                    "session": "alpha",
+                    "branch": "feat/alpha",
+                    "pr": 42,
+                    "pr_state": "OPEN",
+                    "pr_review": "APPROVED",
+                    "pr_merge_state": "CLEAN",
+                    "last_refresh": "2026-04-19T22:15:00Z",
+                    "skipped": False,
+                    "reason": "pr-open",
+                }
+            ],
+        )
+
+        cli_main(["refresh", "--json"])
+
+        data = json.loads(capsys.readouterr().out)
+        assert data[0]["session"] == "alpha"
+        assert data[0]["pr_merge_state"] == "CLEAN"
+
+    def test_refresh_named_subset(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        calls: list[tuple[list[str] | None, str | None]] = []
+
+        def refresh_pr_metadata(*, names=None, repo=None):
+            calls.append((names, repo))
+            return [
+                {
+                    "session": "alpha",
+                    "branch": "feat/alpha",
+                    "pr": 42,
+                    "pr_state": "OPEN",
+                    "pr_review": "APPROVED",
+                    "pr_merge_state": "CLEAN",
+                    "last_refresh": "2026-04-19T22:15:00Z",
+                    "skipped": False,
+                    "reason": "pr-open",
+                }
+            ]
+
+        monkeypatch.setattr(reaper, "refresh_pr_metadata", refresh_pr_metadata)
+
+        cli_main(["refresh", "alpha"])
+
+        assert calls == [(["alpha"], None)]
+        out = capsys.readouterr().out
+        assert "alpha" in out
+        assert "review=APPROVED" in out
+        assert "merge=CLEAN" in out
+
+    def test_refresh_repo_filter(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        calls: list[tuple[list[str] | None, str | None]] = []
+
+        def refresh_pr_metadata(*, names=None, repo=None):
+            calls.append((names, repo))
+            return []
+
+        monkeypatch.setattr(reaper, "refresh_pr_metadata", refresh_pr_metadata)
+
+        cli_main(["refresh", "--repo", "dismech"])
+
+        assert calls == [(None, "dismech")]
+        assert "No sessions to refresh." in capsys.readouterr().out
+
+    def test_ls_all_metadata(self, fake_tmux: FakeTmux, capsys):
+        core.new_session(TEST_SESSION, desc="metadata test")
+        core.set_metadata(TEST_SESSION, "origin", "git-worktree")
+        core.set_metadata(TEST_SESSION, "last_refresh", "2026-04-19T22:15:00Z")
+
+        cli_main(["ls", "--all-metadata"])
+
+        out = capsys.readouterr().out
+        assert "LAST_REFRESH" in out
+        assert "ORIGIN" in out
+        assert "git-worktree" in out
 
     def test_send_with_wait(self, monkeypatch: pytest.MonkeyPatch):
         calls: list[tuple[str, str, bool, float]] = []

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -15,17 +15,35 @@ def _session(name: str, **metadata: str) -> core.SessionInfo:
 
 
 def test_reap_sessions_dry_run_for_merged_pr(monkeypatch):
-    monkeypatch.setattr(reaper.core, "list_sessions", lambda: [_session("alpha", branch="feat/alpha")])
-    monkeypatch.setattr(reaper, "_gh_pr_status", lambda branch: {"number": 42, "state": "MERGED"})
+    set_calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("alpha", branch="feat/alpha")])
+    monkeypatch.setattr(
+        reaper,
+        "_gh_pr_status",
+        lambda branch, *, repo_dir="": {"number": 42, "state": "MERGED", "review": "APPROVED", "merge_state": "CLEAN"},
+    )
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
+    monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: set_calls.append(args))
 
     results = reaper.reap_sessions(dry_run=True)
 
+    assert set_calls == [
+        ("alpha", "pr", "42"),
+        ("alpha", "pr_state", "MERGED"),
+        ("alpha", "pr_review", "APPROVED"),
+        ("alpha", "pr_merge_state", "CLEAN"),
+        ("alpha", "last_refresh", "2026-04-19T22:15:00Z"),
+    ]
     assert results == [
         {
             "session": "alpha",
             "branch": "feat/alpha",
             "pr": 42,
             "pr_state": "MERGED",
+            "pr_review": "APPROVED",
+            "pr_merge_state": "CLEAN",
+            "last_refresh": "2026-04-19T22:15:00Z",
             "killed": False,
             "worktree_removed": False,
             "branch_deleted": False,
@@ -40,8 +58,13 @@ def test_reap_sessions_updates_metadata_and_cleans(monkeypatch):
     set_calls: list[tuple[str, str, str]] = []
     kill_calls: list[str] = []
 
-    monkeypatch.setattr(reaper.core, "list_sessions", lambda: [_session("alpha", branch="feat/alpha")])
-    monkeypatch.setattr(reaper, "_gh_pr_status", lambda branch: {"number": 42, "state": "MERGED"})
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("alpha", branch="feat/alpha")])
+    monkeypatch.setattr(
+        reaper,
+        "_gh_pr_status",
+        lambda branch, *, repo_dir="": {"number": 42, "state": "MERGED", "review": "APPROVED", "merge_state": "CLEAN"},
+    )
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
     monkeypatch.setattr(reaper, "_has_uncommitted", lambda working_dir: False)
     monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: set_calls.append(args))
     monkeypatch.setattr(reaper.core, "kill_session", lambda name: kill_calls.append(name))
@@ -52,14 +75,25 @@ def test_reap_sessions_updates_metadata_and_cleans(monkeypatch):
     results = reaper.reap_sessions()
 
     assert kill_calls == ["alpha"]
-    assert set_calls == [("alpha", "pr", "42"), ("alpha", "pr_state", "MERGED")]
+    assert set_calls == [
+        ("alpha", "pr", "42"),
+        ("alpha", "pr_state", "MERGED"),
+        ("alpha", "pr_review", "APPROVED"),
+        ("alpha", "pr_merge_state", "CLEAN"),
+        ("alpha", "last_refresh", "2026-04-19T22:15:00Z"),
+    ]
     assert results[0]["worktree_removed"] is True
     assert results[0]["branch_deleted"] is True
 
 
 def test_reap_sessions_skips_uncommitted_changes(monkeypatch):
-    monkeypatch.setattr(reaper.core, "list_sessions", lambda: [_session("alpha", branch="feat/alpha")])
-    monkeypatch.setattr(reaper, "_gh_pr_status", lambda branch: {"number": 42, "state": "MERGED"})
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("alpha", branch="feat/alpha")])
+    monkeypatch.setattr(
+        reaper,
+        "_gh_pr_status",
+        lambda branch, *, repo_dir="": {"number": 42, "state": "MERGED", "review": "APPROVED", "merge_state": "CLEAN"},
+    )
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
     monkeypatch.setattr(reaper, "_has_uncommitted", lambda working_dir: True)
     monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: None)
 
@@ -71,6 +105,9 @@ def test_reap_sessions_skips_uncommitted_changes(monkeypatch):
             "branch": "feat/alpha",
             "pr": 42,
             "pr_state": "MERGED",
+            "pr_review": "APPROVED",
+            "pr_merge_state": "CLEAN",
+            "last_refresh": "2026-04-19T22:15:00Z",
             "killed": False,
             "worktree_removed": False,
             "branch_deleted": False,
@@ -81,9 +118,11 @@ def test_reap_sessions_skips_uncommitted_changes(monkeypatch):
 
 
 def test_reap_sessions_include_no_pr(monkeypatch):
-    monkeypatch.setattr(reaper.core, "list_sessions", lambda: [_session("alpha", branch="feat/alpha")])
-    monkeypatch.setattr(reaper, "_gh_pr_status", lambda branch: None)
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("alpha", branch="feat/alpha")])
+    monkeypatch.setattr(reaper, "_gh_pr_status", lambda branch, *, repo_dir="": None)
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
     monkeypatch.setattr(reaper, "_has_uncommitted", lambda working_dir: False)
+    monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: None)
     monkeypatch.setattr(reaper.core, "kill_session", lambda name: None)
     monkeypatch.setattr(reaper.core, "_is_git_worktree", lambda working_dir: False)
     monkeypatch.setattr(reaper.core, "_delete_branch", lambda repo, branch: False)
@@ -92,3 +131,109 @@ def test_reap_sessions_include_no_pr(monkeypatch):
 
     assert results[0]["reason"] == "no-pr"
     assert results[0]["killed"] is True
+
+
+def test_refresh_pr_metadata_updates_fields(monkeypatch):
+    set_calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("alpha", branch="feat/alpha")])
+    monkeypatch.setattr(
+        reaper,
+        "_gh_pr_status",
+        lambda branch, *, repo_dir="": {"number": 42, "state": "OPEN", "review": "APPROVED", "merge_state": "CLEAN"},
+    )
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
+    monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: set_calls.append(args))
+
+    results = reaper.refresh_pr_metadata()
+
+    assert set_calls == [
+        ("alpha", "pr", "42"),
+        ("alpha", "pr_state", "OPEN"),
+        ("alpha", "pr_review", "APPROVED"),
+        ("alpha", "pr_merge_state", "CLEAN"),
+        ("alpha", "last_refresh", "2026-04-19T22:15:00Z"),
+    ]
+    assert results == [
+        {
+            "session": "alpha",
+            "branch": "feat/alpha",
+            "pr": 42,
+            "pr_state": "OPEN",
+            "pr_review": "APPROVED",
+            "pr_merge_state": "CLEAN",
+            "last_refresh": "2026-04-19T22:15:00Z",
+            "skipped": False,
+            "reason": "pr-open",
+        }
+    ]
+
+
+def test_refresh_pr_metadata_queries_in_session_repo_context(monkeypatch):
+    repo_dirs: list[str] = []
+
+    monkeypatch.setattr(
+        reaper.core,
+        "list_sessions",
+        lambda **kwargs: [_session("alpha", branch="feat/alpha", repo="/repo/root")],
+    )
+
+    def fake_gh_pr_status(branch: str, *, repo_dir: str = ""):
+        repo_dirs.append(repo_dir)
+        return {"number": 42, "state": "OPEN", "review": "APPROVED", "merge_state": "CLEAN"}
+
+    monkeypatch.setattr(reaper, "_gh_pr_status", fake_gh_pr_status)
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
+    monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: None)
+
+    reaper.refresh_pr_metadata()
+
+    assert repo_dirs == ["/tmp/alpha"]
+
+
+def test_refresh_pr_metadata_passes_repo_filter_to_list_sessions(monkeypatch):
+    repo_filters: list[str | None] = []
+
+    def list_sessions(*, status=None, repo=None, process=None):
+        del status, process
+        repo_filters.append(repo)
+        return [_session("alpha", branch="feat/alpha")]
+
+    monkeypatch.setattr(reaper.core, "list_sessions", list_sessions)
+    monkeypatch.setattr(
+        reaper,
+        "_gh_pr_status",
+        lambda branch, *, repo_dir="": {"number": 42, "state": "OPEN", "review": "APPROVED", "merge_state": "CLEAN"},
+    )
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
+    monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: None)
+
+    reaper.refresh_pr_metadata(repo="dismech")
+
+    assert repo_filters == ["dismech"]
+
+
+def test_refresh_pr_metadata_clears_stale_fields_when_no_pr(monkeypatch):
+    set_calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        reaper.core,
+        "list_sessions",
+        lambda **kwargs: [_session("alpha", branch="feat/alpha", pr="42", pr_state="OPEN")],
+    )
+    monkeypatch.setattr(reaper, "_gh_pr_status", lambda branch, *, repo_dir="": None)
+    monkeypatch.setattr(reaper.core, "_metadata_timestamp", lambda: "2026-04-19T22:15:00Z")
+    monkeypatch.setattr(reaper.core, "set_metadata", lambda *args: set_calls.append(args))
+
+    results = reaper.refresh_pr_metadata()
+
+    assert set_calls == [
+        ("alpha", "pr", ""),
+        ("alpha", "pr_state", ""),
+        ("alpha", "pr_review", ""),
+        ("alpha", "pr_merge_state", ""),
+        ("alpha", "last_refresh", "2026-04-19T22:15:00Z"),
+    ]
+    assert results[0]["pr"] is None
+    assert results[0]["pr_state"] is None
+    assert results[0]["reason"] == "no-pr"

--- a/tests/test_send_keys_tmux.py
+++ b/tests/test_send_keys_tmux.py
@@ -114,6 +114,28 @@ def wait_for_output(session_name: str, text: str, *, timeout: float = 3.0) -> st
     return output
 
 
+def wait_for_pi_ready(session_name: str, *, timeout: float = 10.0) -> dict:
+    status: dict = {}
+    output = ""
+
+    def is_ready() -> bool:
+        nonlocal status, output
+        output = core.peek_session(session_name, lines=200)
+        status = core.get_session_status(session_name)
+        agent = status.get("agent", {})
+        return (
+            status.get("process") == "pi"
+            and agent.get("type") == "pi"
+            and agent.get("ready") is True
+        )
+
+    try:
+        wait_for(is_ready, timeout=timeout, message="timed out waiting for pi to become ready")
+    except AssertionError as exc:
+        raise AssertionError(f"{exc}\nLast tmux output:\n{output}\nLast status:\n{status}") from exc
+    return status
+
+
 def launch_mock_codex(session_name: str, workdir: Path) -> None:
     command = f"{shlex.quote(sys.executable)} -u {shlex.quote(str(MOCK_CODEX))}"
     core._run(
@@ -174,7 +196,7 @@ def launch_real_pi(session_name: str, workdir: Path, session_dir: Path) -> None:
         ["tmux", "new-session", "-d", "-s", session_name, "-c", str(workdir), command],
         check=True,
     )
-    wait_for_output(session_name, "pi v", timeout=8.0)
+    wait_for_pi_ready(session_name, timeout=10.0)
 
 
 def init_git_repo(path: Path) -> None:
@@ -317,7 +339,7 @@ branch_prefix = "task"
     cli_main(["new", session, "--profile", "pi", "--repo", str(repo)])
 
     expected_worktree = worktrees / f"{repo.name}-{session}"
-    wait_for_output(session, "pi v", timeout=8.0)
+    wait_for_pi_ready(session, timeout=12.0)
 
     status = core.get_session_status(session)
 


### PR DESCRIPTION
## Summary

This adds a non-destructive `tp refresh` workflow for PR metadata, expands the `tp ls` dashboard surface, and updates the docs to reflect `tp`'s current role as a repo/worktree-oriented agent orchestrator.

## What Changed

- added `tp refresh`, including `tp refresh <name>`, `tp refresh --repo NAME`, and `tp refresh --json`
- refactored PR lookup and metadata caching into a shared refresh path used by both `tp refresh` and `tp reap`
- cached `@pr`, `@pr_state`, `@pr_review`, `@pr_merge_state`, and `@last_refresh`
- made `tp reap --dry-run` persist safe PR metadata while keeping destructive actions guarded
- taught `tp status` to show relative freshness for cached metadata
- expanded `tp ls` with a compact `PR` dashboard column plus `REVIEW`, `MERGE_STATE`, `PR_NUM`, and `--all-metadata`
- suppressed noisy `UNKNOWN` merge-state output in `tp status`
- updated README and docs pages to cover the refresh/dashboard workflow and the current built-in Pi launch command

## Why

Previously there was no clean way to refresh PR metadata across sessions without using `tp reap`, and `tp reap --dry-run` did not persist the safe metadata needed for a dashboard. The live refresh path also had a bug where GitHub PR lookups ran in the current checkout instead of the session's own repo/worktree, which could incorrectly cache `no-pr`.

## User Impact

`tp` now works better as a multi-agent review dashboard for worktree-based repo workflows:

- refresh repo-scoped session metadata without cleanup
- see compact PR/review/conflict state directly in `tp ls`
- inspect how fresh cached metadata is in `tp status`
- rely on docs that match the current orchestration conventions

## Validation

- `pytest -q`
- `uv run --group docs mkdocs build`

## Related

- implements #26
- covers the `tp ls` PR dashboard work requested in #25