### PR TITLE
[codex] Fix tp new --directory profile semantics

### DIFF
--- a/docs/how-to/create-sessions.md
+++ b/docs/how-to/create-sessions.md
@@ -65,7 +65,7 @@ tp new review-pass --profile claude -c ~/repos/myapp
 tp new pi-local --profile pi -c ~/repos/pi-mono
 ```
 
-For built-in profiles and custom profiles without a configured `repo`, this uses the selected profile's command in the existing checkout passed by `--directory`. No new worktree is created.
+When `--directory` is present, this uses the selected or default profile's command in the existing checkout passed by `--directory`. No new worktree is created unless you also request bootstrap semantics with `--repo`, `--issue`, `--branch`, or `--base-ref`.
 
 Those commands launch:
 
@@ -99,7 +99,7 @@ Use `--profile` when you want worktree/profile behavior and also want to overrid
 
 ## `--directory` vs `--repo` vs `--here`
 
-- `--directory`: use an existing checkout as the working directory. In plain mode this creates a bare session there. With an explicit built-in or repo-less profile, it launches the selected profile in place.
+- `--directory`: use an existing checkout as the working directory. In plain mode this creates a bare session there. With a resolved profile, it launches that profile in place unless `--repo`, `--issue`, `--branch`, or `--base-ref` requests bootstrap.
 - `--repo`: profile mode bootstrap source. `tp` resolves or clones the repo, creates a task worktree, and launches the selected profile there.
 - `--here`: plain mode only. It uses the current directory, infers repo/branch/worktree metadata, and can infer the session name when `NAME` is omitted.
 

--- a/docs/reference/session-creation.md
+++ b/docs/reference/session-creation.md
@@ -17,7 +17,7 @@ Triggers:
 - no profile settings apply
 - explicit `--here`
 - explicit `--agent` without `--profile`, `--issue`, `--repo`, or `--no-agent`
-- explicit `--directory` when profile/worktree bootstrap mode is not otherwise selected
+- explicit `--directory` when no resolved profile applies
 
 Behavior:
 
@@ -53,12 +53,12 @@ Triggers:
 - `--no-agent`
 - `--branch`
 - `--base-ref`
-- an existing `[default]` profile when plain mode is not forced and `--directory` is absent
+- an existing `[default]` profile when plain mode is not forced
 
 Behavior:
 
 - resolves repo, worktree base, clone base, command, env, base ref, prompt timeout, and branch prefix from the selected profile
-- uses `--directory` for an in-place launch when the resolved profile does not require repo bootstrap
+- uses `--directory` for an in-place launch unless bootstrap semantics were explicitly requested with `--repo`, `--issue`, `--branch`, or `--base-ref`
 - otherwise creates a task worktree from the configured repo and base ref
 - records repo and branch metadata
 - optionally launches the resolved agent
@@ -101,7 +101,7 @@ Supported fields:
 - `--agent`: command to launch in the session, such as `claude`, `claude-code`, or `codex`
 - `--prompt`: initial text to send after the agent launches
 - `NAME`: optional when `--directory` or `--here` is present
-- `--directory`: existing working directory; plain mode creates a bare session there, while an explicit built-in or repo-less profile launches in place
+- `--directory`: existing working directory; plain mode creates a bare session there, while a resolved profile launches in place unless `--repo`, `--issue`, `--branch`, or `--base-ref` asks for bootstrap
 - `--here`: plain mode shortcut for “use the current working directory and infer git metadata”
 - `--repo`: profile mode bootstrap source or repo override
 - `--no-agent`: profile mode only; create the worktree/session but skip launching the configured agent

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -733,10 +733,6 @@ def should_use_profile_mode(
         return True
     if agent:
         return False
-    if prompt:
-        return "default" in profiles and not directory
-    if directory:
-        return False
     return "default" in profiles
 
 
@@ -788,6 +784,23 @@ def resolve_session_profile(
         base_ref=selected.base_ref or default.base_ref,
         prompt_wait_timeout=selected.prompt_wait_timeout or default.prompt_wait_timeout or 10.0,
     )
+
+
+def _should_bootstrap_profile_workspace(
+    *,
+    directory: str | None = None,
+    explicit_repo: str | None = None,
+    configured_repo: str = "",
+    issue: int | None = None,
+    branch: str | None = None,
+    base_ref: str | None = None,
+) -> bool:
+    """Return True when profile mode should create a task worktree."""
+    if explicit_repo or issue is not None or branch or base_ref:
+        return True
+    if directory:
+        return False
+    return bool(configured_repo)
 
 
 def _slugify_branch_component(value: str) -> str:
@@ -1145,9 +1158,19 @@ def create_profile_session(
     if profile is None:
         raise RuntimeError("No profile, agent, or repo bootstrap configuration was resolved")
 
-    repo_source = profile.repo
-    if not repo_source and (issue is not None or branch or base_ref):
-        repo_source = _git_root(directory or os.getcwd())
+    configured_repo_source = profile.repo
+    repo_source = ""
+    if _should_bootstrap_profile_workspace(
+        directory=directory,
+        explicit_repo=repo,
+        configured_repo=configured_repo_source,
+        issue=issue,
+        branch=branch,
+        base_ref=base_ref,
+    ):
+        repo_source = repo or configured_repo_source
+        if not repo_source and (issue is not None or branch or base_ref):
+            repo_source = _git_root(directory or os.getcwd())
     if issue is not None and not repo_source:
         raise RuntimeError("Issue-based sessions require a git repo; pass --repo or run tp from a git checkout")
     if (branch or base_ref) and not repo_source:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1393,6 +1393,49 @@ class TestCLI:
         assert new_calls == [("my-worktree", "/tmp/my-worktree", None)]
         assert "Created session 'my-worktree'" in capsys.readouterr().out
 
+    def test_new_with_directory_uses_default_profile_mode(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        create_calls: list[tuple[str, dict[str, object]]] = []
+        new_calls: list[str] = []
+
+        monkeypatch.setattr(core, "session_exists", lambda name: False)
+        monkeypatch.setattr(
+            core,
+            "load_profiles",
+            lambda path=None: {"default": core.SessionProfile(name="default", command=("codex", "--profile", "yolo"))},
+        )
+        monkeypatch.setattr(
+            core,
+            "create_profile_session",
+            lambda name, **kwargs: create_calls.append((name, kwargs)),
+        )
+        monkeypatch.setattr(
+            core,
+            "new_session",
+            lambda name, *, directory=None, desc=None, command=None: new_calls.append(name),
+        )
+
+        cli_main(["new", "rename-types", "-c", "/tmp/myapp"])
+
+        assert create_calls == [
+            (
+                "rename-types",
+                {
+                    "profile_name": None,
+                    "issue": None,
+                    "agent": None,
+                    "repo": None,
+                    "directory": "/tmp/myapp",
+                    "branch": None,
+                    "base_ref": None,
+                    "no_agent": False,
+                    "prompt": None,
+                    "desc": None,
+                },
+            )
+        ]
+        assert new_calls == []
+        assert "Created session 'rename-types'" in capsys.readouterr().out
+
     def test_new_without_name_auto_uniqueifies_inferred_name(self, monkeypatch: pytest.MonkeyPatch, capsys):
         new_calls: list[tuple[str, str | None, str | None]] = []
         existing = {"agentic-trace-analyzer", "agentic-trace-analyzer-1"}

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -54,6 +54,18 @@ def test_builtin_codex_profile_matches_send_wait_timeout(tmp_path):
     assert profile.prompt_wait_timeout == 30.0
 
 
+def test_should_use_profile_mode_applies_default_profile_with_directory(tmp_path):
+    config = tmp_path / "profiles.toml"
+    config.write_text(
+        """
+[default]
+command = ["codex", "--profile", "yolo"]
+"""
+    )
+
+    assert core.should_use_profile_mode(directory=str(tmp_path), path=config) is True
+
+
 def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monkeypatch, tmp_path):
     profile = core.SessionProfile(
         name="pi",
@@ -239,6 +251,57 @@ def test_create_bootstrap_workspace_does_not_repeat_repo_prefix(monkeypatch, tmp
     ]
     assert result["worktree"] == str(expected_worktree)
     assert result["branch"] == "feat/tmux-pilot-issue-23"
+
+
+def test_create_profile_session_uses_directory_in_place_even_when_profile_has_repo(monkeypatch, tmp_path):
+    profile = core.SessionProfile(
+        name="myapp",
+        repo="~/repos/dismech",
+        command=("codex", "--profile", "yolo"),
+    )
+    metadata_calls: list[tuple[str, str, str]] = []
+    launch_calls: list[tuple[str, str, str | None, str | None, float]] = []
+    new_calls: list[tuple[str, str | None, str | None, str | None]] = []
+
+    monkeypatch.setattr(core, "resolve_session_profile", lambda *args, **kwargs: profile)
+    monkeypatch.setattr(
+        core,
+        "_create_bootstrap_workspace",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("should not bootstrap")),
+    )
+    monkeypatch.setattr(
+        core,
+        "new_session",
+        lambda name, *, directory=None, desc=None, command=None: new_calls.append((name, directory, desc, command)),
+    )
+    monkeypatch.setattr(core, "set_metadata", lambda *args: metadata_calls.append(args))
+    monkeypatch.setattr(
+        core,
+        "launch_agent_session",
+        lambda session_name, command, *, prompt=None, expected_cwd=None, prompt_timeout=30.0: launch_calls.append(
+            (session_name, command, prompt, expected_cwd, prompt_timeout)
+        ),
+    )
+    monkeypatch.setattr(core, "_git_root", lambda path: str(tmp_path.resolve()))
+    monkeypatch.setattr(core, "_detect_git_branch", lambda path: "feat/current")
+
+    result = core.create_profile_session(
+        "rename-types",
+        profile_name="myapp",
+        directory=str(tmp_path),
+    )
+
+    assert new_calls == [("rename-types", str(tmp_path.resolve()), None, None)]
+    assert metadata_calls == [
+        ("rename-types", "task", "rename-types"),
+        ("rename-types", "repo", str(tmp_path.resolve())),
+        ("rename-types", "branch", "feat/current"),
+        ("rename-types", "status", "active"),
+    ]
+    assert launch_calls == [("rename-types", "codex --profile yolo", None, str(tmp_path.resolve()), 10.0)]
+    assert result["repo"] == str(tmp_path.resolve())
+    assert result["worktree"] == str(tmp_path.resolve())
+    assert result["branch"] == "feat/current"
 
 
 def test_resolve_repo_source_clones_github_repo_when_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
Fixes #18 by making `tp new --directory` honor in-place profile semantics consistently.

## What changed
- apply the `[default]` profile for `tp new NAME -c DIR` unless plain mode is explicitly forced by `--agent`
- treat `--directory` as an in-place launch signal, so `--profile X -c DIR` does not bootstrap a worktree just because the resolved profile has `repo` configured
- add regression coverage for CLI mode selection and profile-session bootstrap decisions
- update the session-creation docs to match the shipped behavior

## Root cause
Profile-mode selection skipped the default profile whenever `--directory` was set, while profile session creation treated any resolved `profile.repo` as a bootstrap signal even for explicit in-place launches.

## Validation
- `uv run pytest tests/test_profiles.py tests/test_core.py -q`
- `uv run pytest -q`

## Risk
The main residual risk is that profile mode now wins more often when a `[default]` profile exists, so any workflows that relied on `tp new -c DIR` staying plain despite a configured default will now need `--agent` to force plain mode.
