### PR TITLE
[codex] Avoid duplicate repo prefix in bootstrap worktree paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ When `--repo` is used, `tp new` now handles the full task bootstrap flow:
 - creates a git worktree under the configured worktree base
 - starts the requested agent inside that worktree
 
+Bootstrap worktrees are named `<repo>-<session>` by default. If `NAME` already starts with `<repo>-`, `tp` reuses `NAME` as the worktree leaf directory instead of doubling the repo prefix.
+
 Concrete bootstrap examples:
 
 ```bash

--- a/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
+++ b/docs/how-to/start-task-sessions-with-profiles-and-worktrees.md
@@ -40,6 +40,8 @@ With the default settings, that command:
 3. Creates worktree `~/worktrees/myapp-auth-fix`.
 4. Starts `codex --profile yolo` in that worktree.
 
+Bootstrap worktrees are named `<repo>-<session>` by default. If the session name already starts with `<repo>-`, `tp` reuses that session name as the worktree directory instead of repeating the repo prefix.
+
 Issue-driven example:
 
 ```bash

--- a/docs/reference/session-creation.md
+++ b/docs/reference/session-creation.md
@@ -65,6 +65,8 @@ Behavior:
 - optionally sends `--prompt`
 - verifies that the pane cwd stays on the requested directory or created worktree when launching the agent
 
+Bootstrap worktrees are named `<repo>-<session>` by default. If `NAME` already starts with `<repo>-`, that session name is reused as the worktree leaf directory instead of repeating the repo prefix.
+
 Examples:
 
 ```bash

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -1040,6 +1040,16 @@ def _initial_prompt_desc(desc: str | None, issue_title: str) -> str | None:
     return issue_title or desc
 
 
+def _bootstrap_worktree_leaf_name(repo_name: str, session_name: str) -> str:
+    """Build a stable worktree leaf name without repeating the repo prefix."""
+    repo_name_folded = repo_name.casefold()
+    session_name_folded = session_name.casefold()
+    repo_prefix = f"{repo_name_folded}-"
+    if session_name_folded == repo_name_folded or session_name_folded.startswith(repo_prefix):
+        return session_name
+    return f"{repo_name}-{session_name}"
+
+
 def _create_bootstrap_workspace(
     *,
     profile: SessionProfile,
@@ -1051,7 +1061,7 @@ def _create_bootstrap_workspace(
 ) -> dict[str, str]:
     repo_path = _resolve_repo_source(repo_source, clone_base=profile.clone_base)
     worktree_base = Path(profile.worktree_base).expanduser().resolve()
-    worktree_dir = worktree_base / f"{Path(repo_path).name}-{name}"
+    worktree_dir = worktree_base / _bootstrap_worktree_leaf_name(Path(repo_path).name, name)
 
     branch_name = branch or f"{profile.branch_prefix}/{_slugify_branch_component(name)}"
     if issue is not None and branch is None:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -166,6 +166,74 @@ def test_create_profile_session_launches_agent_in_directory_without_bootstrap(mo
     assert result["worktree"] == str(tmp_path.resolve())
 
 
+def test_create_bootstrap_workspace_prefixes_repo_name_once(monkeypatch, tmp_path):
+    profile = core.SessionProfile(
+        name="codex",
+        worktree_base=str(tmp_path),
+        branch_prefix="feat",
+    )
+    repo_path = str((tmp_path / "tmux-pilot").resolve())
+    prepare_calls: list[tuple[str, Path, str, str]] = []
+
+    monkeypatch.setattr(core, "_resolve_repo_source", lambda repo, *, clone_base: repo_path)
+    monkeypatch.setattr(core, "_detect_base_ref", lambda repo_path, base_ref: "origin/main")
+    monkeypatch.setattr(
+        core,
+        "_prepare_worktree",
+        lambda repo_path, *, worktree_dir, branch, base_ref: prepare_calls.append(
+            (repo_path, worktree_dir, branch, base_ref)
+        ),
+    )
+
+    result = core._create_bootstrap_workspace(
+        profile=profile,
+        name="issue-23",
+        repo_source="~/repos/tmux-pilot",
+    )
+
+    expected_worktree = tmp_path / "tmux-pilot-issue-23"
+
+    assert prepare_calls == [
+        (repo_path, expected_worktree, "feat/issue-23", "origin/main"),
+    ]
+    assert result["worktree"] == str(expected_worktree)
+    assert result["branch"] == "feat/issue-23"
+
+
+def test_create_bootstrap_workspace_does_not_repeat_repo_prefix(monkeypatch, tmp_path):
+    profile = core.SessionProfile(
+        name="codex",
+        worktree_base=str(tmp_path),
+        branch_prefix="feat",
+    )
+    repo_path = str((tmp_path / "tmux-pilot").resolve())
+    prepare_calls: list[tuple[str, Path, str, str]] = []
+
+    monkeypatch.setattr(core, "_resolve_repo_source", lambda repo, *, clone_base: repo_path)
+    monkeypatch.setattr(core, "_detect_base_ref", lambda repo_path, base_ref: "origin/main")
+    monkeypatch.setattr(
+        core,
+        "_prepare_worktree",
+        lambda repo_path, *, worktree_dir, branch, base_ref: prepare_calls.append(
+            (repo_path, worktree_dir, branch, base_ref)
+        ),
+    )
+
+    result = core._create_bootstrap_workspace(
+        profile=profile,
+        name="tmux-pilot-issue-23",
+        repo_source="~/repos/tmux-pilot",
+    )
+
+    expected_worktree = tmp_path / "tmux-pilot-issue-23"
+
+    assert prepare_calls == [
+        (repo_path, expected_worktree, "feat/tmux-pilot-issue-23", "origin/main"),
+    ]
+    assert result["worktree"] == str(expected_worktree)
+    assert result["branch"] == "feat/tmux-pilot-issue-23"
+
+
 def test_resolve_repo_source_clones_github_repo_when_missing(monkeypatch, tmp_path):
     clone_calls: list[tuple[list[str], str | None]] = []
 

--- a/tests/test_send_keys_tmux.py
+++ b/tests/test_send_keys_tmux.py
@@ -335,10 +335,10 @@ branch_prefix = "task"
     )
     monkeypatch.setattr(core, "PROFILE_CONFIG_PATH", config)
 
-    session = "pi-task"
+    session = f"{repo.name}-pi-task"
     cli_main(["new", session, "--profile", "pi", "--repo", str(repo)])
 
-    expected_worktree = worktrees / f"{repo.name}-{session}"
+    expected_worktree = worktrees / session
     wait_for_pi_ready(session, timeout=12.0)
 
     status = core.get_session_status(session)
@@ -346,13 +346,13 @@ branch_prefix = "task"
     assert status["working_dir"] == str(expected_worktree)
     assert status["process"] == "pi"
     assert status["agent"]["type"] == "pi"
-    assert status["metadata"]["branch"] == "task/pi-task"
+    assert status["metadata"]["branch"] == f"task/{session}"
     assert subprocess.run(
         ["git", "-C", str(expected_worktree), "rev-parse", "--abbrev-ref", "HEAD"],
         check=True,
         capture_output=True,
         text=True,
-    ).stdout.strip() == "task/pi-task"
+    ).stdout.strip() == f"task/{session}"
 
     core.send_keys(session, "/name tmux-pilot-pi")
     wait_for_output(session, "Session name set: tmux-pilot-pi", timeout=5.0)


### PR DESCRIPTION
## Summary
- avoid doubling the repo basename in `tp new --repo` worktree paths when the session name already starts with that basename
- keep branch naming unchanged while preserving the existing `<repo>-<session>` worktree pattern for other session names
- document the naming rule and add focused unit and integration coverage

## Root Cause
Bootstrap worktree paths were always built as `<repo>-<session>`, so names like `tmux-pilot-issue-23` became `tmux-pilot-tmux-pilot-issue-23`.

## Validation
- `pytest tests/test_profiles.py tests/test_send_keys_tmux.py -k 'bootstraps_worktree_and_launches_real_pi or test_create_bootstrap_workspace_prefixes_repo_name_once or test_create_bootstrap_workspace_does_not_repeat_repo_prefix'`

Fixes #23