### PR TITLE
[codex] Add session trace inspection views

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ tp ls
 tp refresh --repo myapp
 tp ls --cols NAME,PR,STATUS,DIR
 
+# Inspect the transcript trace bound to a session
+tp trace auth-flow
+
 # Peek at output without attaching
 tp peek auth-flow -n 30
 
@@ -92,6 +95,8 @@ tp ls --all-metadata           # append known metadata columns
 tp ls --cols NAME,PR,DIR       # compact PR dashboard
 tp ls --json --status active   # combine filters with JSON
 ```
+
+`tp ls --all-metadata` also exposes cached trace fields such as `TRACE_AGENT` and `TRACE_PATH`.
 
 `PR` is a compact summary column. It starts with the PR number, then appends short review/merge codes when available:
 
@@ -260,6 +265,28 @@ PR-related metadata is shown with refresh ages when available, for example:
 @last_refresh = 2026-04-19T22:39:42.658Z
 ```
 
+When a transcript has been resolved, `tp status` also shows the cached `@trace_agent` and `@trace_path` metadata for that session.
+
+### `tp trace` — Inspect the bound transcript trace
+
+Use this when a tmux pane cwd is not the whole story and you want the actual transcript binding that `tp` will use for agent state.
+
+```bash
+tp trace auth-flow
+tp trace auth-flow --refresh
+tp trace auth-flow --json
+tp trace auth-flow --show raw --lines 10
+tp trace auth-flow --show json
+tp trace auth-flow --show yaml
+tp trace auth-flow --show tsv
+tp trace auth-flow --show formatted
+tp trace auth-flow --show yaml --color always
+```
+
+`tp trace` prefers cached session metadata (`@trace_agent`, `@trace_path`) and falls back to a cwd-based scan when needed. This makes it practical for one `tp` session to stay associated with one chat/session trace even after later checks no longer rely purely on `pane_current_path`.
+
+Use `--json` for machine-readable trace metadata. Use `--show raw|json|yaml|tsv|formatted` when you want the transcript content itself, whether the underlying file is a Codex, Claude Code, or Pi JSONL trace. `tsv` emits normalized rows for scripts, while `formatted` renders a readable timeline. `--color auto|always|never` controls ANSI coloring for the human-readable render modes.
+
 ### `tp refresh` — Refresh PR metadata without reaping
 
 Use this when you want a review dashboard or fresh PR metadata without any destructive cleanup.
@@ -275,7 +302,7 @@ tp refresh --json               # machine-readable output
 
 ### `tp set` / `tp get` — Session metadata
 
-Metadata is stored as tmux user options (`@`-prefixed). Common built-in keys include `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, `last_send`, `pr`, `pr_state`, `pr_review`, `pr_merge_state`, and `last_refresh`.
+Metadata is stored as tmux user options (`@`-prefixed). Common built-in keys include `repo`, `task`, `desc`, `status`, `origin`, `branch`, `needs`, `last_send`, `pr`, `pr_state`, `pr_review`, `pr_merge_state`, `last_refresh`, `trace_agent`, and `trace_path`.
 
 ```bash
 tp set NAME status "waiting-for-review"
@@ -325,6 +352,7 @@ done
 - **Process detection** — distinguishes claude-code vs codex vs bare shell
 - **Task bootstrap** — create task branches and worktrees directly from `tp new --repo`
 - **PR refresh** — cache PR number, state, review state, and merge state with `tp refresh`
+- **Trace binding** — cache the transcript trace for a session with `tp trace`
 - **Metadata** — tmux user options (@status, @desc, @repo, @branch, @pr, etc.)
 - **Metadata freshness** — `tp status` shows when cached fields were last updated
 - **Peek without attaching** — critical for orchestrators monitoring sessions

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -88,6 +88,7 @@ tp jump docs-pass
 tp peek docs-pass -n 30
 tp peek docs-pass -n 100
 tp status docs-pass
+tp trace docs-pass
 ```
 
 Use `tp peek` when you need recent output but do not want to take over your terminal with `tmux attach`.
@@ -125,6 +126,19 @@ tp get docs-pass branch
 ```
 
 Built-in metadata is also surfaced through `tp status` and `tp ls --json`.
+
+When you need the transcript binding rather than pane scrollback, use:
+
+```bash
+tp trace docs-pass
+tp trace docs-pass --refresh
+tp trace docs-pass --show raw --lines 10
+tp trace docs-pass --show json
+tp trace docs-pass --show yaml
+tp trace docs-pass --show tsv
+tp trace docs-pass --show formatted
+tp trace docs-pass --show yaml --color always
+```
 
 ## Refresh PR Metadata And Build A Review Dashboard
 

--- a/docs/explanation/file-backed-agent-state.md
+++ b/docs/explanation/file-backed-agent-state.md
@@ -18,6 +18,8 @@ The transcript tells `tp` whether the agent is running or has finished a turn. T
 
 `tp send --wait` only proceeds when both conditions line up.
 
+To keep one tmux session associated with one agent/chat trace, `tp` now also caches the resolved transcript binding on the session itself. Once a transcript has been resolved, later checks can reuse that binding instead of re-discovering it purely from cwd every time.
+
 ## Why transcripts
 
 Structured transcript files are more stable than terminal text. They survive scrollback truncation and expose agent events directly instead of forcing `tp` to infer state from visible strings.
@@ -26,6 +28,9 @@ Current supported sources:
 
 - Codex transcripts under `$CODEX_HOME/sessions` or `~/.codex/sessions`
 - Claude Code transcripts under `CLAUDE_PROJECTS_DIR` or `~/.claude/projects`
+- Pi session files under `PI_CODING_AGENT_DIR/sessions` or the built-in worktree-local `.tmux-pilot/pi/sessions`
+
+The initial discovery path is still cwd-based, but it now feeds a cached session binding (`@trace_agent`, `@trace_path`) that can be inspected with `tp trace`.
 
 ## Why keep tmux pane checks
 
@@ -47,4 +52,5 @@ Real-world use has clarified a few product boundaries:
 - `tp new --agent "codex --profile yolo --no-alt-screen"` plus `tp send --wait` is a meaningful improvement over the older one-shot send model.
 - Codex trust prompts are normal in brand-new repos and worktrees. They should be treated as an explicit product state, not hand-waved away as a transient glitch.
 - Session metadata alone is not enough to trust launch correctness. `tp` must verify the live pane cwd before and immediately after agent launch, because a shell or agent can drift away from the requested directory while metadata still looks correct.
+- Once a transcript has been discovered, the session should keep using that trace as its stable binding. This gives orchestrators a durable handle for future features such as conversation summaries and richer state inspection.
 - Low-level setup commands and first-class worktree-aware creation are still missing features. When users need them, that should be recorded as a blocker or roadmap item rather than normalized as a permanent shell-script workaround.

--- a/docs/reference/agent-state.md
+++ b/docs/reference/agent-state.md
@@ -1,6 +1,6 @@
 # Agent State Reference
 
-This page documents the current agent-state and readiness behavior used by `tp status`, `tp ls --json`, and `tp send --wait`.
+This page documents the current agent-state and readiness behavior used by `tp status`, `tp trace`, `tp ls --json`, and `tp send --wait`.
 
 ## `tp send --wait`
 
@@ -47,6 +47,10 @@ States that are not first-class yet:
 Relevant keys for steering:
 
 - `last_send`: updated after a successful `tp send`
+- `trace_agent`: cached transcript-backed agent type for the session
+- `trace_path`: cached transcript path bound to the session
+
+`tp` now prefers a cached session trace binding when it exists. If no cached binding is present, it falls back to matching the tmux pane cwd against transcript `cwd` data and then caches the result for later status and wait checks.
 
 ## Transcript sources
 
@@ -54,13 +58,13 @@ Relevant keys for steering:
 
 - transcript root: `$CODEX_HOME/sessions`
 - default root when unset: `~/.codex/sessions`
-- session matching: tmux pane working directory to transcript `cwd`
+- first match strategy: cached `@trace_path`, then tmux pane working directory to transcript `cwd`
 
 ### Claude Code
 
 - transcript root: `CLAUDE_PROJECTS_DIR`
 - default root when unset: `~/.claude/projects`
-- session matching: tmux pane working directory to transcript `cwd`
+- first match strategy: cached `@trace_path`, then tmux pane working directory to transcript `cwd`
 
 `CLAUDE_PROJECTS_DIR` is primarily useful for tests or nonstandard layouts. Claude Code itself normally writes under `~/.claude/projects`.
 
@@ -69,7 +73,7 @@ Relevant keys for steering:
 - default transcript root: `~/.pi/agent/sessions/--<cwd>--`
 - configurable root: `PI_CODING_AGENT_DIR/sessions/--<cwd>--`
 - built-in `tp` profile root: `{worktree}/.tmux-pilot/pi/sessions`
-- session matching: tmux pane working directory to session header `cwd`
+- first match strategy: cached `@trace_path`, then tmux pane working directory to session header `cwd`
 
 ## Agent-specific behavior
 
@@ -102,6 +106,10 @@ If no session file is available yet, `tp` falls back to the visible Pi footer an
 ### Generic agents
 
 Generic sessions do not have file-backed state. `tp` uses pane heuristics only.
+
+## Trace Inspection
+
+Use `tp trace NAME` when you want the exact transcript binding a session is using. This is especially helpful if the pane cwd and the agent's effective working trace have diverged.
 
 ## Known gaps
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -12,6 +12,7 @@ This page is the compact command reference for `tp`. For longer walkthroughs, us
 | `tp send` | send the next instruction into a live session |
 | `tp jump` | attach or switch to a session |
 | `tp status` | inspect process, cwd, metadata, and recent output |
+| `tp trace` | inspect the transcript trace bound to a session |
 | `tp clean` | remove done-ish sessions and their worktrees |
 | `tp kill` | kill a session immediately |
 | `tp set` / `tp get` | manage tmux-backed session metadata |
@@ -132,8 +133,33 @@ tp status docs-pass
 - working directory
 - tmux metadata
 - metadata freshness for cached fields such as PR state
+- cached trace metadata when a transcript has been resolved
 - current agent state
 - recent scrollback
+
+## `tp trace`
+
+```bash
+tp trace docs-pass
+tp trace docs-pass --refresh
+tp trace docs-pass --json
+tp trace docs-pass --show raw --lines 10
+tp trace docs-pass --show json
+tp trace docs-pass --show yaml
+tp trace docs-pass --show tsv
+tp trace docs-pass --show formatted
+tp trace docs-pass --show yaml --color always
+```
+
+`tp trace` resolves the transcript associated with a session, preferring cached `@trace_agent` / `@trace_path` metadata and falling back to a cwd-based scan when needed. This is the command to use when you want to verify which chat/session trace a tmux session is actually bound to.
+
+- `--json` prints the trace binding metadata as JSON
+- `--show raw` prints raw JSONL lines from the transcript
+- `--show json` pretty-prints transcript records as a JSON array
+- `--show yaml` renders transcript records in a YAML-like view
+- `--show tsv` emits normalized transcript rows with tab-separated columns
+- `--show formatted` renders a readable timestamped transcript timeline
+- `--color auto|always|never` controls ANSI color for `--show raw|json|yaml|formatted`
 
 ## `tp clean`
 
@@ -176,6 +202,15 @@ tp refresh --json
 ```
 
 `tp refresh` updates cached PR metadata only. It writes `@pr`, `@pr_state`, `@pr_review`, `@pr_merge_state`, and `@last_refresh`, but it does not kill sessions, remove worktrees, or delete branches.
+
+## Trace Metadata
+
+When `tp` resolves a transcript for a session, it caches:
+
+- `@trace_agent`
+- `@trace_path`
+
+These cached fields are visible in `tp status`, `tp ls --all-metadata`, and `tp ls --json`.
 
 ## `tp reap`
 

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -64,6 +64,7 @@ Useful `core` helpers for automation:
 - `create_profile_session(...)`
 - `wait_until_session_ready(...)`
 - `get_session_status(...)`
+- `get_session_trace(...)`
 - `kill_session(...)`
 
 ## Install Or Remove Git Hooks
@@ -95,6 +96,15 @@ from tmux_pilot import reaper
 
 result = reaper.refresh_pr_metadata(repo="myapp")
 print(result)
+```
+
+## Inspect A Session Trace
+
+```python
+from tmux_pilot import core
+
+trace = core.get_session_trace("docs-pass", refresh=False, lines=5)
+print(trace["agent"], trace["path"])
 ```
 
 ## Recommendation

--- a/src/tmux_pilot/agent_sessions.py
+++ b/src/tmux_pilot/agent_sessions.py
@@ -10,6 +10,7 @@ from pathlib import Path
 _TRANSCRIPT_SCAN_LIMIT = 200
 _HEAD_SCAN_LINES = 8
 _READ_CHUNK_SIZE = 8192
+SUPPORTED_AGENT_TYPES = ("codex", "claude-code", "pi")
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,11 @@ def pi_sessions_root() -> Path:
     """Return the Pi sessions directory."""
     agent_dir = Path(os.environ.get("PI_CODING_AGENT_DIR", "~/.pi/agent")).expanduser()
     return agent_dir / "sessions"
+
+
+def is_supported_agent_type(agent_type: str) -> bool:
+    """Return True when *agent_type* has transcript support."""
+    return agent_type in SUPPORTED_AGENT_TYPES
 
 
 def _normalize_cwd(cwd: str) -> str:
@@ -103,6 +109,36 @@ def transcript_cwd(path: Path, *, max_lines: int = _HEAD_SCAN_LINES) -> str:
                     return _normalize_cwd(cwd)
     except OSError:
         return ""
+    return ""
+
+
+def _first_record(path: Path, *, max_lines: int = _HEAD_SCAN_LINES) -> dict | None:
+    try:
+        with path.open(encoding="utf-8", errors="replace") as handle:
+            for index, line in enumerate(handle):
+                if index >= max_lines:
+                    break
+                record = _load_json_line(line)
+                if record is not None:
+                    return record
+    except OSError:
+        return None
+    return None
+
+
+def infer_transcript_agent_type(path: Path) -> str:
+    """Infer the owning agent type for a transcript file."""
+    record = _first_record(path)
+    if record is None:
+        return ""
+
+    record_type = record.get("type")
+    if record_type == "session_meta":
+        return "codex"
+    if record_type == "session" and record.get("version") == 3:
+        return "pi"
+    if record_type in {"user", "assistant"} and isinstance(record.get("sessionId"), str):
+        return "claude-code"
     return ""
 
 
@@ -416,3 +452,64 @@ def get_pi_transcript_state(
     if path is None:
         return None
     return read_pi_transcript_state(path)
+
+
+def read_transcript_state(agent_type: str, path: Path) -> TranscriptState | None:
+    """Read transcript state for *agent_type* from *path*."""
+    if agent_type == "codex":
+        return read_codex_transcript_state(path)
+    if agent_type == "claude-code":
+        return read_claude_transcript_state(path)
+    if agent_type == "pi":
+        return read_pi_transcript_state(path)
+    return None
+
+
+def read_transcript_tail(path: Path, *, lines: int = 20) -> list[str]:
+    """Return the last *lines* raw JSONL lines from *path*."""
+    if lines <= 0:
+        return []
+
+    tail: list[str] = []
+    for line in _iter_lines_reverse(path):
+        tail.append(line)
+        if len(tail) >= lines:
+            break
+    tail.reverse()
+    return tail
+
+
+def read_transcript_records(
+    path: Path,
+    *,
+    limit: int | None = 20,
+) -> list[dict]:
+    """Return JSON records from *path*, preserving file order.
+
+    When *limit* is provided, returns the last N valid JSON object records.
+    When *limit* is None, returns every valid JSON object record in the file.
+    """
+    records: list[dict] = []
+    if limit is not None and limit <= 0:
+        return records
+
+    if limit is None:
+        try:
+            with path.open(encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    record = _load_json_line(line)
+                    if record is not None:
+                        records.append(record)
+        except OSError:
+            return []
+        return records
+
+    for line in _iter_lines_reverse(path):
+        record = _load_json_line(line)
+        if record is None:
+            continue
+        records.append(record)
+        if len(records) >= limit:
+            break
+    records.reverse()
+    return records

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -9,7 +9,7 @@ import sys
 
 from pathlib import Path
 
-from . import core, display, hooks
+from . import agent_sessions, core, display, hooks
 
 
 _NEW_DESCRIPTION = """Create a tmux session.
@@ -195,6 +195,412 @@ def cmd_status(args: argparse.Namespace) -> None:
         print(str(e), file=sys.stderr)
         sys.exit(1)
     print(display.format_status(info))
+
+
+_ANSI_RESET = "\033[0m"
+_ANSI_KEY = "\033[36m"
+_ANSI_STRING = "\033[32m"
+_ANSI_NUMBER = "\033[33m"
+_ANSI_BOOL = "\033[35m"
+_ANSI_NULL = "\033[2m"
+
+
+def _style(text: str, code: str, *, color: bool) -> str:
+    if not color:
+        return text
+    return f"{code}{text}{_ANSI_RESET}"
+
+
+def _json_scalar(value: object, *, color: bool) -> str:
+    if isinstance(value, str):
+        return _style(json.dumps(value, ensure_ascii=False), _ANSI_STRING, color=color)
+    if isinstance(value, bool):
+        return _style("true" if value else "false", _ANSI_BOOL, color=color)
+    if value is None:
+        return _style("null", _ANSI_NULL, color=color)
+    return _style(json.dumps(value, ensure_ascii=False), _ANSI_NUMBER, color=color)
+
+
+def _json_key(value: str, *, color: bool) -> str:
+    return _style(json.dumps(value, ensure_ascii=False), _ANSI_KEY, color=color)
+
+
+def _json_inline(value: object, *, color: bool) -> str:
+    if isinstance(value, dict):
+        items = [f"{_json_key(str(key), color=color)}: {_json_inline(child, color=color)}" for key, child in value.items()]
+        return "{" + ", ".join(items) + "}"
+    if isinstance(value, list):
+        return "[" + ", ".join(_json_inline(item, color=color) for item in value) + "]"
+    return _json_scalar(value, color=color)
+
+
+def _json_dump(value: object, *, indent: int = 0, color: bool = False) -> list[str]:
+    prefix = " " * indent
+
+    if isinstance(value, dict):
+        if not value:
+            return [f"{prefix}{{}}"]
+        lines = [f"{prefix}{{"]
+        items = list(value.items())
+        for index, (key, child) in enumerate(items):
+            comma = "," if index < len(items) - 1 else ""
+            nested = _json_dump(child, indent=indent + 2, color=color)
+            if len(nested) == 1:
+                lines.append(f"{' ' * (indent + 2)}{_json_key(str(key), color=color)}: {nested[0].lstrip()}{comma}")
+            else:
+                lines.append(f"{' ' * (indent + 2)}{_json_key(str(key), color=color)}: {nested[0].lstrip()}")
+                lines.extend(nested[1:])
+                lines[-1] += comma
+        lines.append(f"{prefix}}}")
+        return lines
+
+    if isinstance(value, list):
+        if not value:
+            return [f"{prefix}[]"]
+        lines = [f"{prefix}["]
+        for index, item in enumerate(value):
+            comma = "," if index < len(value) - 1 else ""
+            nested = _json_dump(item, indent=indent + 2, color=color)
+            if len(nested) == 1:
+                lines.append(f"{' ' * (indent + 2)}{nested[0].lstrip()}{comma}")
+            else:
+                lines.extend(nested)
+                lines[-1] += comma
+        lines.append(f"{prefix}]")
+        return lines
+
+    return [f"{prefix}{_json_scalar(value, color=color)}"]
+
+
+def _yaml_scalar(value: object, *, color: bool) -> str:
+    if isinstance(value, str):
+        return _style(json.dumps(value, ensure_ascii=False), _ANSI_STRING, color=color)
+    if isinstance(value, bool):
+        return _style("true" if value else "false", _ANSI_BOOL, color=color)
+    if value is None:
+        return _style("null", _ANSI_NULL, color=color)
+    return _style(json.dumps(value, ensure_ascii=False), _ANSI_NUMBER, color=color)
+
+
+def _yaml_dump(value: object, *, indent: int = 0, color: bool = False) -> list[str]:
+    prefix = " " * indent
+
+    if isinstance(value, dict):
+        if not value:
+            return [f"{prefix}{{}}"]
+        lines: list[str] = []
+        for key, child in value.items():
+            if isinstance(child, (dict, list)):
+                lines.append(f"{prefix}{_style(str(key), _ANSI_KEY, color=color)}:")
+                lines.extend(_yaml_dump(child, indent=indent + 2, color=color))
+            else:
+                lines.append(f"{prefix}{_style(str(key), _ANSI_KEY, color=color)}: {_yaml_scalar(child, color=color)}")
+        return lines
+
+    if isinstance(value, list):
+        if not value:
+            return [f"{prefix}[]"]
+        lines = []
+        for item in value:
+            if isinstance(item, (dict, list)):
+                nested = _yaml_dump(item, indent=indent + 2, color=color)
+                first = nested[0].lstrip()
+                lines.append(f"{prefix}- {first}")
+                lines.extend(f"{prefix}  {line.lstrip()}" for line in nested[1:])
+            else:
+                lines.append(f"{prefix}- {_yaml_scalar(item, color=color)}")
+        return lines
+
+    return [f"{prefix}{_yaml_scalar(value, color=color)}"]
+
+
+def _should_use_color(mode: str) -> bool:
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    return sys.stdout.isatty()
+
+
+def _compact_text(text: object) -> str:
+    if text is None:
+        return ""
+    if isinstance(text, str):
+        return " ".join(text.split())
+    return " ".join(str(text).split())
+
+
+def _item_summary(item: object) -> str:
+    if isinstance(item, str):
+        return _compact_text(item)
+    if not isinstance(item, dict):
+        return _compact_text(item)
+
+    item_type = item.get("type")
+    if item_type == "text":
+        return _compact_text(item.get("text", ""))
+    if item_type == "tool_use":
+        name = _compact_text(item.get("name", "tool"))
+        tool_input = item.get("input")
+        if isinstance(tool_input, dict):
+            command = _compact_text(tool_input.get("command", ""))
+            if command:
+                return f"tool {name}: {command}"
+        return f"tool {name}"
+    if item_type == "toolCall":
+        name = _compact_text(item.get("name", "tool"))
+        arguments = item.get("arguments")
+        if isinstance(arguments, dict):
+            command = _compact_text(arguments.get("command", ""))
+            if command:
+                return f"tool {name}: {command}"
+        return f"tool {name}"
+    return _compact_text(json.dumps(item, ensure_ascii=False, sort_keys=True))
+
+
+def _content_summary(content: object) -> str:
+    if isinstance(content, list):
+        parts = [_item_summary(item) for item in content]
+        return " | ".join(part for part in parts if part)
+    if isinstance(content, dict):
+        return _compact_text(json.dumps(content, ensure_ascii=False, sort_keys=True))
+    return _compact_text(content)
+
+
+def _payload_summary(payload: object) -> str:
+    if isinstance(payload, dict):
+        if "content" in payload:
+            summary = _content_summary(payload.get("content"))
+            if summary:
+                return summary
+        if "cwd" in payload:
+            cwd = _compact_text(payload.get("cwd", ""))
+            if cwd:
+                return f"cwd={cwd}"
+        return _compact_text(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return _compact_text(payload)
+
+
+def _normalize_trace_record(agent_type: str, record: dict) -> dict[str, str]:
+    timestamp = _compact_text(record.get("timestamp", ""))
+    turn_id = _compact_text(record.get("turn_id") or record.get("uuid") or record.get("id") or "")
+    kind = _compact_text(record.get("type", "")) or "record"
+    role = ""
+    summary = ""
+
+    if agent_type == "codex":
+        if kind in {"session_meta", "turn_context"}:
+            role = "session" if kind == "session_meta" else "context"
+            summary = _payload_summary(record.get("payload", {}))
+        elif kind == "event_msg":
+            role = "event"
+            payload = record.get("payload", {})
+            if isinstance(payload, dict):
+                event_type = _compact_text(payload.get("type", "event"))
+                turn_id = _compact_text(payload.get("turn_id", "")) or turn_id
+                reason = _compact_text(payload.get("reason", ""))
+                summary = event_type
+                if reason:
+                    summary = f"{summary} ({reason})"
+            else:
+                summary = _payload_summary(payload)
+        else:
+            summary = _payload_summary(record.get("payload", record))
+    elif agent_type == "claude-code":
+        message = record.get("message", {})
+        if isinstance(message, dict):
+            role = _compact_text(message.get("role", kind))
+            summary = _content_summary(message.get("content"))
+        if not summary:
+            summary = _payload_summary(record)
+    elif agent_type == "pi":
+        if kind == "session":
+            role = "session"
+            cwd = _compact_text(record.get("cwd", ""))
+            summary = f"cwd={cwd}" if cwd else _payload_summary(record)
+        elif kind == "message":
+            message = record.get("message", {})
+            if isinstance(message, dict):
+                role = _compact_text(message.get("role", "message"))
+                summary = _content_summary(message.get("content"))
+                stop_reason = _compact_text(message.get("stopReason", ""))
+                if stop_reason and stop_reason not in {"stop"}:
+                    summary = f"{summary} ({stop_reason})" if summary else stop_reason
+            if not summary:
+                summary = _payload_summary(record)
+        else:
+            summary = _payload_summary(record)
+    else:
+        if kind == "event_msg":
+            role = "event"
+            payload = record.get("payload", {})
+            if isinstance(payload, dict):
+                summary = _compact_text(payload.get("type", "event"))
+                turn_id = _compact_text(payload.get("turn_id", "")) or turn_id
+            else:
+                summary = _payload_summary(payload)
+        else:
+            message = record.get("message")
+            if isinstance(message, dict):
+                role = _compact_text(message.get("role", kind))
+                summary = _content_summary(message.get("content"))
+            if not summary:
+                summary = _payload_summary(record.get("payload", record))
+
+    return {
+        "timestamp": timestamp,
+        "kind": kind or "-",
+        "role": role or "-",
+        "turn_id": turn_id or "-",
+        "summary": summary or "-",
+    }
+
+
+def _trace_rows(trace: dict[str, object], *, lines: int, all_records: bool) -> list[dict[str, str]]:
+    path = str(trace.get("path", "") or "")
+    if not path:
+        return []
+
+    transcript_path = Path(path)
+    record_limit = None if all_records else (lines if lines > 0 else 20)
+    records = agent_sessions.read_transcript_records(transcript_path, limit=record_limit)
+    agent_type = _compact_text(trace.get("agent", "")) or agent_sessions.infer_transcript_agent_type(transcript_path)
+    return [_normalize_trace_record(agent_type, record) for record in records]
+
+
+def _trace_tsv(rows: list[dict[str, str]]) -> str:
+    header = ["timestamp", "kind", "role", "turn_id", "summary"]
+    out = ["\t".join(header)]
+    for row in rows:
+        out.append("\t".join(row[field].replace("\t", " ") for field in header))
+    return "\n".join(out)
+
+
+def _role_style(label: str, *, color: bool) -> str:
+    palette = {
+        "user": _ANSI_STRING,
+        "assistant": _ANSI_KEY,
+        "event": _ANSI_NUMBER,
+        "session": _ANSI_BOOL,
+        "context": _ANSI_NULL,
+        "toolresult": _ANSI_NUMBER,
+        "bashexecution": _ANSI_NUMBER,
+    }
+    code = palette.get(label.lower(), _ANSI_KEY)
+    return _style(label, code, color=color)
+
+
+def _trace_formatted(rows: list[dict[str, str]], *, color: bool) -> str:
+    if not rows:
+        return ""
+    width = max(len(row["role"]) for row in rows)
+    lines = []
+    for row in rows:
+        label = row["role"]
+        if label == "-" and row["kind"] != "-":
+            label = row["kind"]
+        turn = "" if row["turn_id"] in {"", "-"} else f" [{row['turn_id']}]"
+        lines.append(
+            f"{row['timestamp'] or '-'}  {_role_style(label.ljust(width), color=color)}{turn}  {row['summary']}"
+        )
+    return "\n".join(lines)
+
+
+def _trace_content(
+    trace: dict[str, object],
+    *,
+    show: str,
+    lines: int,
+    all_records: bool,
+    color: bool,
+) -> str:
+    path = str(trace.get("path", "") or "")
+    if not path:
+        return ""
+
+    transcript_path = Path(path)
+    if show == "raw":
+        if color:
+            record_limit = None if all_records else (lines if lines > 0 else 20)
+            records = agent_sessions.read_transcript_records(transcript_path, limit=record_limit)
+            return "\n".join(_json_inline(record, color=True) for record in records)
+        if all_records:
+            try:
+                return transcript_path.read_text(encoding="utf-8", errors="replace").rstrip()
+            except OSError:
+                return ""
+        limit = lines if lines > 0 else 20
+        return "\n".join(agent_sessions.read_transcript_tail(transcript_path, lines=limit))
+
+    record_limit = None if all_records else (lines if lines > 0 else 20)
+    records = agent_sessions.read_transcript_records(transcript_path, limit=record_limit)
+    if show == "json":
+        return "\n".join(_json_dump(records, color=color))
+    if show == "yaml":
+        return "\n".join(_yaml_dump(records, color=color))
+    if show == "tsv":
+        return _trace_tsv(_trace_rows(trace, lines=lines, all_records=all_records))
+    if show == "formatted":
+        return _trace_formatted(_trace_rows(trace, lines=lines, all_records=all_records), color=color)
+    return ""
+
+
+def cmd_trace(args: argparse.Namespace) -> None:
+    try:
+        trace = core.get_session_trace(
+            args.name,
+            refresh=args.refresh,
+            lines=args.lines if args.show == "summary" else 0,
+        )
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(trace, indent=2))
+        return
+
+    path = str(trace.get("path", "") or "")
+    if not path:
+        print(f"No transcript trace found for session '{args.name}'.")
+        return
+
+    if args.show != "summary":
+        content = _trace_content(
+            trace,
+            show=args.show,
+            lines=args.lines,
+            all_records=args.all,
+            color=_should_use_color(args.color),
+        )
+        if content:
+            print(content)
+        return
+
+    lines = [
+        f"Session:    {trace['session']}",
+        f"Agent:      {trace.get('agent', '') or '-'}",
+        f"Binding:    {trace.get('source', '') or '-'}",
+        f"Pane Dir:   {trace.get('pane_working_dir', '') or '-'}",
+        f"Trace Dir:  {trace.get('transcript_cwd', '') or '-'}",
+        f"Path:       {path}",
+    ]
+    if trace.get("state"):
+        lines.append(f"State:      {trace['state']}")
+    if trace.get("timestamp"):
+        lines.append(f"Last Event: {trace['timestamp']}")
+    if trace.get("turn_id"):
+        lines.append(f"Turn:       {trace['turn_id']}")
+
+    tail = trace.get("tail", [])
+    if isinstance(tail, list) and tail:
+        lines.append("")
+        lines.append("Tail:")
+        lines.append("─" * 60)
+        lines.extend(str(line) for line in tail)
+        lines.append("─" * 60)
+
+    print("\n".join(lines))
 
 
 def cmd_kill(args: argparse.Namespace) -> None:
@@ -441,6 +847,26 @@ def build_parser() -> argparse.ArgumentParser:
     p_status = sub.add_parser("status", help="Detailed session status")
     p_status.add_argument("name", help="Session name")
 
+    # trace
+    p_trace = sub.add_parser("trace", help="Inspect the transcript trace bound to a session")
+    p_trace.add_argument("name", help="Session name")
+    p_trace.add_argument("--refresh", action="store_true", help="Rescan by pane cwd before falling back to cached trace metadata")
+    p_trace.add_argument("--json", action="store_true", help="Output trace info as JSON")
+    p_trace.add_argument(
+        "--show",
+        choices=("summary", "raw", "json", "yaml", "tsv", "formatted"),
+        default="summary",
+        help="Show the trace summary or render transcript content as raw JSONL, pretty JSON, YAML, TSV, or a formatted timeline",
+    )
+    p_trace.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help="Colorize human transcript output when using --show raw|json|yaml",
+    )
+    p_trace.add_argument("-n", "--lines", type=int, default=0, help="Show the last N transcript lines or records")
+    p_trace.add_argument("--all", action="store_true", help="Show the full transcript instead of the last N lines or records")
+
     # clean
     p_clean = sub.add_parser("clean", help="Bulk cleanup of done-ish sessions + worktrees")
     p_clean.add_argument("name", nargs="?", default=None, help="Clean a specific session")
@@ -503,6 +929,7 @@ def main(argv: list[str] | None = None) -> None:
         "send": cmd_send,
         "jump": cmd_jump,
         "status": cmd_status,
+        "trace": cmd_trace,
         "clean": cmd_clean,
         "kill": cmd_kill,
         "set": cmd_set,

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -34,6 +34,8 @@ METADATA_KEYS = (
     "pr_merge_state",
     "last_refresh",
     "pushing",
+    "trace_agent",
+    "trace_path",
 )
 
 # Map pane_current_command to friendly process names
@@ -644,6 +646,29 @@ def _command_to_agent_fields(command: tuple[str, ...]) -> tuple[str, str]:
     return command[0], " ".join(command[1:])
 
 
+def _infer_trace_agent_from_command(command: str) -> str:
+    """Infer a transcript-backed agent type from a launch command string."""
+    if not command:
+        return ""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+
+    executable = ""
+    for part in parts:
+        if "=" in part and not part.startswith(("/", ".", "~")):
+            continue
+        executable = Path(part).name.lower()
+        break
+
+    if executable == "claude":
+        return "claude-code"
+    if executable in {"claude-code", "codex", "pi"}:
+        return executable
+    return ""
+
+
 def load_profiles(path: Path | None = None) -> dict[str, SessionProfile]:
     """Load configured session profiles from TOML."""
     config_path = path or PROFILE_CONFIG_PATH
@@ -805,6 +830,9 @@ def launch_agent_session(
     prompt_timeout: float = 30.0,
 ) -> None:
     """Launch a shell command in a tmux session and optionally send a prompt."""
+    trace_agent = _infer_trace_agent_from_command(command)
+    if trace_agent:
+        set_metadata(session_name, "trace_agent", trace_agent)
     if expected_cwd:
         _ensure_session_cwd(session_name, expected_cwd)
     send_keys(session_name, command)
@@ -1192,6 +1220,126 @@ def _get_agent_state(
     )
 
 
+def _cache_session_trace(
+    session_name: str,
+    *,
+    agent_type: str,
+    transcript_path: Path,
+    meta: dict[str, str] | None = None,
+) -> None:
+    """Persist a stable transcript binding on the tmux session."""
+    normalized_path = _normalize_directory(str(transcript_path))
+    if not normalized_path:
+        return
+
+    if meta is None or meta.get("trace_agent", "") != agent_type:
+        set_metadata(session_name, "trace_agent", agent_type)
+        if meta is not None:
+            meta["trace_agent"] = agent_type
+    if meta is None or meta.get("trace_path", "") != normalized_path:
+        set_metadata(session_name, "trace_path", normalized_path)
+        if meta is not None:
+            meta["trace_path"] = normalized_path
+
+
+def _resolve_session_trace(
+    session_name: str,
+    *,
+    pane_cmd: str = "",
+    pane_path: str = "",
+    pane_pid: str = "",
+    meta: dict[str, str] | None = None,
+    refresh: bool = False,
+    lines: int = 0,
+) -> dict[str, object]:
+    """Resolve the transcript trace bound to a tmux session."""
+    from . import agent_sessions
+
+    if not pane_cmd and not pane_path and not pane_pid and meta is None:
+        pane_cmd, pane_path, pane_pid, meta = _session_pane_details(session_name)
+    if meta is None:
+        meta = {}
+
+    detected_process = _detect_process(pane_cmd, session_name, pane_pid)
+    agent_type = meta.get("trace_agent", "")
+    if not agent_sessions.is_supported_agent_type(agent_type):
+        agent_type = detected_process if agent_sessions.is_supported_agent_type(detected_process) else ""
+
+    cached_path_str = meta.get("trace_path", "")
+    cached_path = Path(cached_path_str).expanduser() if cached_path_str else None
+    if cached_path is not None:
+        try:
+            cached_path = cached_path.resolve()
+        except OSError:
+            cached_path = cached_path.expanduser()
+    if not agent_type and cached_path is not None and cached_path.exists():
+        agent_type = agent_sessions.infer_transcript_agent_type(cached_path)
+
+    dynamic_agent = detected_process if agent_sessions.is_supported_agent_type(detected_process) else agent_type
+    dynamic_path: Path | None = None
+    if dynamic_agent and pane_path and (refresh or cached_path is None or not cached_path.exists()):
+        dynamic_path = agent_sessions.find_transcript_for_cwd(dynamic_agent, pane_path)
+
+    transcript_path: Path | None = None
+    source = "none"
+    if dynamic_path is not None:
+        transcript_path = dynamic_path
+        source = "dynamic"
+        agent_type = dynamic_agent
+    elif cached_path is not None and cached_path.exists():
+        transcript_path = cached_path
+        source = "cached"
+
+    transcript_state = None
+    transcript_cwd = ""
+    tail: list[str] = []
+    if transcript_path is not None:
+        if agent_type:
+            _cache_session_trace(
+                session_name,
+                agent_type=agent_type,
+                transcript_path=transcript_path,
+                meta=meta,
+            )
+            transcript_state = agent_sessions.read_transcript_state(agent_type, transcript_path)
+        transcript_cwd = agent_sessions.transcript_cwd(transcript_path)
+        tail = agent_sessions.read_transcript_tail(transcript_path, lines=lines)
+
+    return {
+        "session": session_name,
+        "agent": agent_type,
+        "path": _normalize_directory(str(transcript_path)) if transcript_path is not None else "",
+        "source": source,
+        "pane_working_dir": pane_path,
+        "transcript_cwd": transcript_cwd,
+        "state": transcript_state.state if transcript_state is not None else "",
+        "timestamp": transcript_state.timestamp if transcript_state is not None else "",
+        "turn_id": transcript_state.turn_id if transcript_state is not None else "",
+        "tail": tail,
+    }
+
+
+def get_session_trace(
+    name: str,
+    *,
+    refresh: bool = False,
+    lines: int = 0,
+) -> dict[str, object]:
+    """Return the transcript trace bound to a tmux session."""
+    if not session_exists(name):
+        raise RuntimeError(f"Session '{name}' not found")
+    pane_cmd, pane_path, pane_pid, meta = _session_pane_details(name)
+    return _resolve_session_trace(
+        name,
+        pane_cmd=pane_cmd,
+        pane_path=pane_path,
+        pane_pid=pane_pid,
+        meta=meta,
+        refresh=refresh,
+        lines=lines,
+    )
+
+
 def _session_pane_details(name: str) -> tuple[str, str, str, dict[str, str]]:
     """Fetch pane command, path, pid, and metadata in one tmux call."""
     pane_fmt = "#{pane_current_command}\t#{pane_current_path}\t#{pane_pid}\t" + _META_FMT
@@ -1234,11 +1382,16 @@ def wait_until_session_ready(
     if not session_exists(name):
         raise RuntimeError(f"Session '{name}' not found")
 
-    from . import agent_sessions
-
     pane_cmd, pane_path, pane_pid, _meta = _session_pane_details(name)
     detected_process = _detect_process(pane_cmd, name, pane_pid)
-    transcript_path: Path | None = None
+    trace = _resolve_session_trace(
+        name,
+        pane_cmd=pane_cmd,
+        pane_path=pane_path,
+        pane_pid=pane_pid,
+        meta=_meta,
+    )
+    transcript_path = Path(str(trace["path"])) if trace.get("path") else None
     deadline = time.monotonic() + timeout
 
     while True:
@@ -1251,10 +1404,17 @@ def wait_until_session_ready(
             transcript_path=transcript_path,
         )
 
-        agent_type = agent.get("type")
-        if isinstance(agent_type, str) and pane_path and transcript_path is None:
-            transcript_path = agent_sessions.find_transcript_for_cwd(agent_type, pane_path)
-            if transcript_path is not None:
+        if transcript_path is None:
+            trace = _resolve_session_trace(
+                name,
+                pane_cmd=pane_cmd,
+                pane_path=pane_path,
+                pane_pid=pane_pid,
+                meta=_meta,
+                refresh=True,
+            )
+            if trace.get("path"):
+                transcript_path = Path(str(trace["path"]))
                 agent = _get_agent_state(
                     name,
                     detected_process,
@@ -1380,12 +1540,21 @@ def get_session_status(name: str) -> dict:
         raise RuntimeError(f"Session '{name}' not found")
 
     pane_cmd, pane_path, pane_pid, meta = _session_pane_details(name)
+    trace = _resolve_session_trace(
+        name,
+        pane_cmd=pane_cmd,
+        pane_path=pane_path,
+        pane_pid=pane_pid,
+        meta=meta,
+    )
     metadata_updated_at = _get_metadata_updated_at(name, list(meta))
     scrollback = peek_session(name, lines=5)
+    transcript_path = Path(str(trace["path"])) if trace.get("path") else None
     agent = _get_agent_state(
         name,
         _detect_process(pane_cmd, name, pane_pid),
         pane_path=pane_path,
+        transcript_path=transcript_path,
     )
 
     return {
@@ -1397,4 +1566,5 @@ def get_session_status(name: str) -> dict:
         "metadata_updated_at": metadata_updated_at,
         "scrollback_tail": scrollback,
         "agent": agent,
+        "trace": trace,
     }

--- a/src/tmux_pilot/display.py
+++ b/src/tmux_pilot/display.py
@@ -25,6 +25,8 @@ _ALL_METADATA_COLUMN_NAMES = [
     "MERGE_STATE",
     "LAST_REFRESH",
     "PUSHING",
+    "TRACE_AGENT",
+    "TRACE_PATH",
 ]
 
 # All available columns: (long_name, mnemonic, accessor)
@@ -49,6 +51,8 @@ ALL_COLUMNS: list[tuple[str, str, ColumnAccessor]] = [
     ("LAST_SEND", "L", lambda s: s.metadata.get("last_send", "") or "-"),
     ("LAST_REFRESH", "F", lambda s: s.metadata.get("last_refresh", "") or "-"),
     ("PUSHING", "U", lambda s: s.metadata.get("pushing", "") or "-"),
+    ("TRACE_AGENT", "C", lambda s: s.metadata.get("trace_agent", "") or "-"),
+    ("TRACE_PATH", "H", lambda s: _shorten_path(s.metadata.get("trace_path", "")) or "-"),
 ]
 
 _COL_BY_MNEMONIC = {m: (name, acc) for name, m, acc in ALL_COLUMNS}

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -56,6 +56,16 @@ def test_find_codex_transcript_for_cwd_prefers_most_recent_match(tmp_path: Path)
     assert found == newer
 
 
+def test_infer_transcript_agent_type_detects_codex(tmp_path: Path):
+    transcript = tmp_path / "sessions" / "rollout.jsonl"
+    _write(
+        transcript,
+        ['{"timestamp":"2026-03-29T20:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}\n'],
+    )
+
+    assert agent_sessions.infer_transcript_agent_type(transcript) == "codex"
+
+
 def test_find_claude_transcript_for_cwd_prefers_most_recent_match(tmp_path: Path):
     root = tmp_path / "projects"
     older = root / "-tmp-project" / "older.jsonl"
@@ -252,3 +262,41 @@ def test_read_pi_transcript_state_reports_completed_from_assistant_stop(tmp_path
         timestamp="2026-03-29T20:00:03Z",
         turn_id="msg-2",
     )
+
+
+def test_read_transcript_tail_returns_latest_lines(tmp_path: Path):
+    transcript = tmp_path / "sessions" / "rollout.jsonl"
+    _write(
+        transcript,
+        [
+            '{"line":1}\n',
+            '{"line":2}\n',
+            '{"line":3}\n',
+        ],
+    )
+
+    assert agent_sessions.read_transcript_tail(transcript, lines=2) == ['{"line":2}', '{"line":3}']
+
+
+def test_read_transcript_records_reads_latest_claude_records(tmp_path: Path):
+    transcript = tmp_path / "projects" / "-tmp-project" / "session.jsonl"
+    _write(
+        transcript,
+        [
+            '{"cwd":"/tmp/project","sessionId":"claude-1","type":"user","message":{"role":"user","content":"hello"},"uuid":"msg-1","timestamp":"2026-03-29T20:00:00Z"}\n',
+            '{"cwd":"/tmp/project","sessionId":"claude-1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]},"uuid":"msg-2","timestamp":"2026-03-29T20:00:01Z"}\n',
+        ],
+    )
+
+    records = agent_sessions.read_transcript_records(transcript, limit=1)
+
+    assert records == [
+        {
+            "cwd": "/tmp/project",
+            "sessionId": "claude-1",
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}]},
+            "uuid": "msg-2",
+            "timestamp": "2026-03-29T20:00:01Z",
+        }
+    ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,9 @@ import json
 import re
 import shlex
 import subprocess
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -453,6 +455,36 @@ class TestWaitForReady:
         with pytest.raises(RuntimeError, match="Timed out waiting for session '_tp_test_session'"):
             core.wait_until_session_ready(TEST_SESSION, timeout=0.5, interval=0.1)
 
+    def test_wait_until_session_ready_uses_cached_trace_path(
+        self,
+        fake_tmux: FakeTmux,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ):
+        transcript = tmp_path / "rollout.jsonl"
+        transcript.write_text(
+            '{"timestamp":"2026-03-29T20:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/worktree"}}\n',
+            encoding="utf-8",
+        )
+        core.new_session(TEST_SESSION, directory="/tmp/example")
+        fake_tmux.sessions[TEST_SESSION]["command"] = "codex"
+        core.set_metadata(TEST_SESSION, "trace_agent", "codex")
+        core.set_metadata(TEST_SESSION, "trace_path", str(transcript))
+        monkeypatch.setattr(core, "peek_session", lambda name, lines=30: "OpenAI Codex")
+
+        transcript_paths: list[Path | None] = []
+
+        def fake_get_agent_state(*args, **kwargs):
+            transcript_paths.append(kwargs.get("transcript_path"))
+            return {"type": "codex", "state": "completed", "ready": True}
+
+        monkeypatch.setattr(core, "_get_agent_state", fake_get_agent_state)
+
+        agent = core.wait_until_session_ready(TEST_SESSION, timeout=1.0, interval=0.1)
+
+        assert agent == {"type": "codex", "state": "completed", "ready": True}
+        assert transcript_paths == [transcript]
+
 
 class TestResolveSession:
     def test_exact_match(self, fake_tmux: FakeTmux):
@@ -501,6 +533,90 @@ class TestStatus:
     def test_status_nonexistent(self, fake_tmux: FakeTmux):
         with pytest.raises(RuntimeError, match="not found"):
             core.get_session_status("_tp_nonexistent_xyz")
+
+
+class TestTrace:
+    def test_get_session_trace_discovers_and_caches_transcript(
+        self,
+        fake_tmux: FakeTmux,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ):
+        transcript = tmp_path / "rollout.jsonl"
+        transcript.write_text(
+            "\n".join(
+                [
+                    '{"timestamp":"2026-03-29T20:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/example"}}',
+                    '{"timestamp":"2026-03-29T20:00:01Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-3"}}',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        core.new_session(TEST_SESSION, directory="/tmp/example")
+        fake_tmux.sessions[TEST_SESSION]["command"] = "codex"
+        monkeypatch.setattr(agent_sessions, "find_transcript_for_cwd", lambda agent_type, cwd, limit=200: transcript)
+
+        trace = core.get_session_trace(TEST_SESSION)
+
+        assert trace["agent"] == "codex"
+        assert trace["path"] == str(transcript.resolve())
+        assert trace["source"] == "dynamic"
+        assert trace["transcript_cwd"] == str(Path("/tmp/example").resolve())
+        assert trace["state"] == "completed"
+        assert fake_tmux.sessions[TEST_SESSION]["metadata"]["trace_agent"] == "codex"
+        assert fake_tmux.sessions[TEST_SESSION]["metadata"]["trace_path"] == str(transcript.resolve())
+
+    def test_get_session_trace_prefers_cached_binding_over_pane_cwd(
+        self,
+        fake_tmux: FakeTmux,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ):
+        transcript = tmp_path / "rollout.jsonl"
+        transcript.write_text(
+            '{"timestamp":"2026-03-29T20:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/worktree"}}\n',
+            encoding="utf-8",
+        )
+        core.new_session(TEST_SESSION, directory="/tmp/main")
+        fake_tmux.sessions[TEST_SESSION]["command"] = "codex"
+        core.set_metadata(TEST_SESSION, "trace_agent", "codex")
+        core.set_metadata(TEST_SESSION, "trace_path", str(transcript))
+
+        calls: list[tuple[str, str]] = []
+
+        def fake_find(agent_type: str, cwd: str, limit: int = 200):
+            calls.append((agent_type, cwd))
+            return None
+
+        monkeypatch.setattr(agent_sessions, "find_transcript_for_cwd", fake_find)
+
+        trace = core.get_session_trace(TEST_SESSION)
+
+        assert trace["source"] == "cached"
+        assert trace["transcript_cwd"] == str(Path("/tmp/worktree").resolve())
+        assert calls == []
+
+    def test_get_session_status_exposes_trace_info(
+        self,
+        fake_tmux: FakeTmux,
+        tmp_path,
+    ):
+        transcript = tmp_path / "rollout.jsonl"
+        transcript.write_text(
+            '{"timestamp":"2026-03-29T20:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/worktree"}}\n',
+            encoding="utf-8",
+        )
+        core.new_session(TEST_SESSION, directory="/tmp/main")
+        fake_tmux.sessions[TEST_SESSION]["command"] = "codex"
+        core.set_metadata(TEST_SESSION, "trace_agent", "codex")
+        core.set_metadata(TEST_SESSION, "trace_path", str(transcript))
+
+        info = core.get_session_status(TEST_SESSION)
+
+        assert info["trace"]["path"] == str(transcript.resolve())
+        assert info["metadata"]["trace_agent"] == "codex"
+        assert info["metadata"]["trace_path"] == str(transcript.resolve())
 
 
 class TestFiltering:
@@ -685,6 +801,7 @@ class TestDisplay:
                         "origin": "git-worktree",
                         "last_refresh": "2026-04-19T22:15:00Z",
                         "pr_state": "OPEN",
+                        "trace_agent": "codex",
                     },
                 )
             ],
@@ -694,6 +811,7 @@ class TestDisplay:
         assert "ORIGIN" in result
         assert "LAST_REFRESH" in result
         assert "PR_STATE" in result
+        assert "TRACE_AGENT" in result
         assert "git-worktree" in result
 
     def test_cols_all_mnemonics(self):
@@ -895,6 +1013,253 @@ class TestCLI:
         assert calls == [(None, "dismech")]
         assert "No sessions to refresh." in capsys.readouterr().out
 
+    def test_trace_json(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": "/tmp/trace.jsonl",
+                "source": "cached",
+                "pane_working_dir": "/tmp/worktree",
+                "transcript_cwd": "/tmp/worktree",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "turn-9",
+                "tail": ['{"type":"event_msg"}'],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--json", "--lines", "1"])
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["agent"] == "codex"
+        assert data["path"] == "/tmp/trace.jsonl"
+
+    def test_trace_show_raw(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text('{"type":"user"}\n{"type":"assistant"}\n', encoding="utf-8")
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/worktree",
+                "transcript_cwd": "/tmp/worktree",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "turn-9",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--show", "raw", "--lines", "1"])
+
+        assert capsys.readouterr().out.strip() == '{"type":"assistant"}'
+
+    def test_trace_show_json_uses_pretty_records(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text('{"type":"user","message":"hello"}\n', encoding="utf-8")
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/worktree",
+                "transcript_cwd": "/tmp/worktree",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "turn-9",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--show", "json"])
+
+        data = json.loads(capsys.readouterr().out)
+        assert data == [{"type": "user", "message": "hello"}]
+
+    def test_trace_show_json_color_always_emits_ansi(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text('{"type":"user","message":"hello"}\n', encoding="utf-8")
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/worktree",
+                "transcript_cwd": "/tmp/worktree",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "turn-9",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--show", "json", "--color", "always"])
+
+        out = capsys.readouterr().out
+        assert "\x1b[" in out
+        assert '"type"' in out
+
+    def test_trace_show_json_color_auto_respects_non_tty(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text('{"type":"user","message":"hello"}\n', encoding="utf-8")
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/worktree",
+                "transcript_cwd": "/tmp/worktree",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "turn-9",
+                "tail": [],
+            },
+        )
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+
+        cli_main(["trace", "alpha", "--show", "json", "--color", "auto"])
+
+        out = capsys.readouterr().out
+        assert "\x1b[" not in out
+        data = json.loads(out)
+        assert data == [{"type": "user", "message": "hello"}]
+
+    def test_trace_show_yaml_handles_claude_records(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text(
+            '{"cwd":"/tmp/project","sessionId":"claude-1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "claude-code",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/project",
+                "transcript_cwd": "/tmp/project",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "msg-9",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--show", "yaml"])
+
+        out = capsys.readouterr().out
+        assert "sessionId: \"claude-1\"" in out
+        assert "role: \"assistant\"" in out
+        assert "text: \"done\"" in out
+
+    def test_trace_show_tsv_handles_claude_records(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text(
+            '{"cwd":"/tmp/project","sessionId":"claude-1","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"pwd"}}]},"uuid":"msg-2","timestamp":"2026-03-29T20:00:02Z"}\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "claude-code",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/project",
+                "transcript_cwd": "/tmp/project",
+                "state": "running",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "msg-2",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--show", "tsv"])
+
+        out = capsys.readouterr().out.strip().splitlines()
+        assert out[0] == "timestamp\tkind\trole\tturn_id\tsummary"
+        assert out[1] == "2026-03-29T20:00:02Z\tassistant\tassistant\tmsg-2\ttool Bash: pwd"
+
+    def test_trace_show_formatted_handles_codex_records(self, monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
+        transcript = tmp_path / "trace.jsonl"
+        transcript.write_text(
+            "\n".join(
+                [
+                    '{"timestamp":"2026-03-29T20:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}',
+                    '{"timestamp":"2026-03-29T20:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}',
+                    '{"timestamp":"2026-03-29T20:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": str(transcript),
+                "source": "cached",
+                "pane_working_dir": "/tmp/project",
+                "transcript_cwd": "/tmp/project",
+                "state": "completed",
+                "timestamp": "2026-04-20T00:00:00Z",
+                "turn_id": "turn-1",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha", "--show", "formatted", "--color", "never"])
+
+        out = capsys.readouterr().out
+        assert "2026-03-29T20:00:00Z  session" in out
+        assert "cwd=/tmp/project" in out
+        assert "2026-03-29T20:00:01Z  event" in out
+        assert "[turn-1]  task_started" in out
+        assert "[turn-1]  task_complete" in out
+
+    def test_trace_human_output_when_missing(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(
+            core,
+            "get_session_trace",
+            lambda name, refresh=False, lines=0: {
+                "session": name,
+                "agent": "codex",
+                "path": "",
+                "source": "none",
+                "pane_working_dir": "/tmp/worktree",
+                "transcript_cwd": "",
+                "state": "",
+                "timestamp": "",
+                "turn_id": "",
+                "tail": [],
+            },
+        )
+
+        cli_main(["trace", "alpha"])
+
+        assert "No transcript trace found for session 'alpha'." in capsys.readouterr().out
+
     def test_ls_all_metadata(self, fake_tmux: FakeTmux, capsys):
         core.new_session(TEST_SESSION, desc="metadata test")
         core.set_metadata(TEST_SESSION, "origin", "git-worktree")
@@ -1062,8 +1427,10 @@ class TestCLI:
     def test_launch_agent_session_waits_before_prompt(self, monkeypatch: pytest.MonkeyPatch):
         send_keys_calls: list[tuple[str, str]] = []
         send_text_calls: list[tuple[str, str, bool, float]] = []
+        metadata_calls: list[tuple[str, str, str]] = []
 
         monkeypatch.setattr(core, "send_keys", lambda name, text: send_keys_calls.append((name, text)))
+        monkeypatch.setattr(core, "set_metadata", lambda name, key, value: metadata_calls.append((name, key, value)))
         monkeypatch.setattr(
             core,
             "send_text",
@@ -1074,6 +1441,7 @@ class TestCLI:
 
         assert send_keys_calls == [(TEST_SESSION, "codex")]
         assert send_text_calls == [(TEST_SESSION, "1+3", True, 12.0)]
+        assert metadata_calls == [(TEST_SESSION, "trace_agent", "codex")]
 
     def test_launch_agent_session_restores_expected_cwd_before_launch(self, fake_tmux: FakeTmux, tmp_path):
         expected_cwd = str(tmp_path)


### PR DESCRIPTION
## Summary
This PR makes transcript traces a first-class session concept instead of treating them as a transient cwd lookup.

Changes in this PR:
- cache a session's resolved transcript binding in tmux metadata as `@trace_agent` and `@trace_path`
- reuse that binding for `tp status` and `tp send --wait`
- add `tp trace` to inspect the bound trace
- add transcript render modes for `tp trace`: `raw`, `json`, `yaml`, `tsv`, and `formatted`
- add `--color auto|always|never` for human-readable trace rendering
- expose trace metadata through `tp ls --all-metadata`
- update README and docs to describe the session-to-trace model and the new CLI surfaces

## Why
A single `tp` session should be associated with a single agent/chat trace. The old behavior discovered transcripts dynamically from pane cwd, which breaks down when the pane cwd and the agent's effective trace diverge. This PR gives `tp` a stable session-level trace binding and a practical way to inspect or consume the underlying transcript.

## User impact
- orchestrators can rely on a durable session-to-trace binding
- users can inspect trace metadata with `tp trace --json`
- users can read trace content directly with `tp trace --show ...`
- downstream tools can use `--show tsv` for script-friendly trace summaries

## Validation
- `pytest -q`
- `uv run --group docs mkdocs build`
