### PR TITLE
[codex] Add trusted publishing and tp prod orchestration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,35 @@
-name: Publish to PyPI
+name: Publish Python Package
 
 on:
+  workflow_dispatch:
   release:
-    types: [published]
-
-permissions:
-  id-token: write
+    types: [created]
 
 jobs:
-  publish:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
-
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
 
       - name: Build package
         run: uv build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ tp ls --cols NAME,PR,STATUS,DIR
 # Inspect the transcript trace bound to a session
 tp trace auth-flow
 
+# Turn PR state into the next follow-up prompt
+tp prod --dry-run --repo myapp
+
 # Peek at output without attaching
 tp peek auth-flow -n 30
 
@@ -205,6 +208,17 @@ extends = "codex"
 repo = "~/repos/myapp"
 branch_prefix = "feat"
 base_ref = "origin/main"
+
+[prod]
+[[prod.rules]]
+name = "changes-requested"
+match = { pr_review = "CHANGES_REQUESTED", pr_state = "OPEN" }
+prompt = "Address all requested review comments on {pr_display}. Re-check each thread, update tests, and push the fixes."
+
+[[prod.rules]]
+name = "merge-blocked"
+match = { pr_state = "OPEN", pr_merge_state = ["BLOCKED", "DIRTY"] }
+prompt = "Your PR {pr_display} is not mergeable. Resolve the conflicts or other merge blockers, then push an update."
 ```
 
 `extends` can target another configured profile or one of the built-in profiles above. Config values override the inherited profile, so you can keep reusable agent defaults separate from repo-specific task defaults.
@@ -242,6 +256,19 @@ tp send NAME "any command"     # sends text + Enter
 tp send --wait NAME "follow-up instruction"
 tp send NAME "claude-code --print 'fix the auth bug'"
 ```
+
+### `tp prod` — Send configured follow-up prompts
+
+```bash
+tp prod                        # all sessions, auto-refresh first
+tp prod dragon-assign          # one named session
+tp prod --repo dismech         # repo-scoped subset
+tp prod --dry-run --repo myapp # preview prompts without sending
+tp prod --json                 # machine-readable plan
+tp prod --wait dragon-assign   # opt into wait-until-ready before sending
+```
+
+`tp prod` reads `[prod]` rules from `~/.config/tmux-pilot/profiles.toml`, refreshes PR metadata by default, picks the first matching rule for each targeted session, renders its prompt template, and sends it via plain `tp send` semantics. Use `--no-refresh` to rely on cached metadata instead. Pass `--wait` only when you explicitly want to wait for readiness before sending.
 
 ### `tp jump` — Attach or switch to a session
 
@@ -301,6 +328,15 @@ tp refresh --json               # machine-readable output
 ```
 
 `tp refresh` updates `@pr`, `@pr_state`, `@pr_review`, `@pr_merge_state`, and `@last_refresh` in tmux metadata. It does not kill sessions, remove worktrees, or delete branches.
+
+`tp prod` builds directly on those cached fields, so the common orchestration loop is:
+
+```bash
+tp refresh --repo myapp
+tp ls --cols NAME,PR,STATUS,DIR --repo myapp
+tp prod --dry-run --repo myapp
+tp prod --repo myapp
+```
 
 ### `tp set` / `tp get` — Session metadata
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,6 +116,8 @@ tp kill docs-pass
 
 Use `tp refresh` before `tp ls` when you want a current review dashboard. The compact `PR` column folds together the PR number plus short review/merge codes such as `A`, `CR`, `RR`, `D`, and `C`.
 
+When you want the next follow-up prompt to be driven by cached PR state instead of hand-written each time, use `tp prod --dry-run` to preview the configured prod rules and `tp prod` to send them.
+
 ## Minimal Profile Config
 
 Create `~/.config/tmux-pilot/profiles.toml` when you want reusable defaults:
@@ -131,6 +133,12 @@ extends = "claude"
 repo = "~/repos/myapp"
 branch_prefix = "fix"
 base_ref = "origin/main"
+
+[prod]
+[[prod.rules]]
+name = "changes-requested"
+match = { pr_review = "CHANGES_REQUESTED", pr_state = "OPEN" }
+prompt = "Address all requested review comments on {pr_display}, update tests as needed, and push the fixes."
 ```
 
 Concrete examples:
@@ -141,6 +149,10 @@ tp new review-pass --profile claude -c ~/repos/myapp
 
 # Use repo/bootstrap defaults from [profiles.myapp]
 tp new issue-771 --profile myapp --issue 771
+
+# Preview or send the next prod prompt based on cached PR state
+tp prod --dry-run --repo myapp
+tp prod --repo myapp
 ```
 
 ## Local Docs Preview

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -10,6 +10,7 @@ This page is the compact command reference for `tp`. For longer walkthroughs, us
 | `tp new` | create a bare session or a profile-backed task session |
 | `tp peek` | view recent scrollback without attaching |
 | `tp send` | send the next instruction into a live session |
+| `tp prod` | send configured follow-up prompts based on PR/session state |
 | `tp jump` | attach or switch to a session |
 | `tp status` | inspect process, cwd, metadata, and recent output |
 | `tp trace` | inspect the transcript trace bound to a session |
@@ -111,6 +112,37 @@ tp send docs-pass "summarize the failing tests"
 tp send --wait docs-pass "write regression coverage for the callback"
 tp send --wait --timeout 90 docs-pass "continue with the next failure"
 ```
+
+## `tp prod`
+
+```bash
+tp prod
+tp prod dragon-assign
+tp prod --repo myapp
+tp prod --dry-run --repo myapp
+tp prod --json
+tp prod --no-refresh
+tp prod --wait dragon-assign
+```
+
+`tp prod` reads `[prod]` rules from `~/.config/tmux-pilot/profiles.toml`, refreshes PR metadata by default, and picks the first matching rule for each session. By default it sends immediately; pass `--wait` when you explicitly want readiness checks first.
+
+Example config:
+
+```toml
+[prod]
+[[prod.rules]]
+name = "changes-requested"
+match = { pr_review = "CHANGES_REQUESTED", pr_state = "OPEN" }
+prompt = "Address all requested review comments on {pr_display}, update tests as needed, and push the fixes."
+
+[[prod.rules]]
+name = "merge-blocked"
+match = { pr_state = "OPEN", pr_merge_state = ["BLOCKED", "DIRTY"] }
+prompt = "Your PR {pr_display} is not mergeable. Resolve the merge blockers, then push an update."
+```
+
+Available match/template fields include the session name plus flattened metadata such as `repo`, `branch`, `desc`, `status`, `pr`, `pr_state`, `pr_review`, and `pr_merge_state`.
 
 ## `tp jump`
 

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -21,6 +21,11 @@ from tmux_pilot import __version__
 print(__version__)
 ```
 
+`__version__` comes from the installed package metadata, with a git-describe
+fallback when you import directly from a source checkout. In tagged or post-tag
+git builds, it follows the git-derived version computed by the release tooling
+rather than a hardcoded string in the source tree.
+
 ## List Sessions
 
 ```python

--- a/docs/reference/session-creation.md
+++ b/docs/reference/session-creation.md
@@ -96,6 +96,11 @@ Supported fields:
 - `agent`: legacy alias for `command`; still accepted
 - `agent_args`: legacy stable flags appended to `agent`; still accepted
 
+`profiles.toml` can also carry orchestration rules for `tp prod`:
+
+- `[prod].refresh`: whether `tp prod` refreshes PR metadata before matching rules
+- `[[prod.rules]]`: ordered first-match rules with `match = {...}` and `prompt = "..."`
+
 ## Option Semantics
 
 - `--agent`: command to launch in the session, such as `claude`, `claude-code`, or `codex`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
 name = "tmux-pilot"
-version = "0.3.0"
+dynamic = ["version"]
 description = "A thin, opinionated CLI for managing tmux sessions that run AI coding agents"
 readme = "README.md"
 license = "MIT"
@@ -50,6 +50,14 @@ docs = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+fallback-version = "0.0.0"
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/tmux_pilot/__init__.py
+++ b/src/tmux_pilot/__init__.py
@@ -1,3 +1,44 @@
 """tmux-pilot: manage tmux sessions for AI coding agents."""
 
-__version__ = "0.3.0"
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+import subprocess
+
+
+def _version_from_git() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--dirty", "--long", "--match", "v[0-9]*"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "0.0.0"
+    desc = result.stdout.strip()
+    if not desc:
+        return "0.0.0"
+    dirty = desc.endswith("-dirty")
+    if dirty:
+        desc = desc[: -len("-dirty")]
+    if desc.startswith("v"):
+        desc = desc[1:]
+    parts = desc.rsplit("-", 2)
+    if len(parts) == 3 and parts[1].isdigit() and parts[2].startswith("g"):
+        base, distance, sha = parts
+        if distance == "0":
+            normalized = base
+        else:
+            normalized = f"{base}.post{distance}+{sha}"
+    else:
+        normalized = desc
+    if dirty:
+        normalized = f"{normalized}.dirty" if "+" in normalized else f"{normalized}+dirty"
+    return normalized
+
+try:
+    __version__ = version("tmux-pilot")
+except PackageNotFoundError:
+    __version__ = _version_from_git()

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -180,6 +180,66 @@ def cmd_send(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def cmd_prod(args: argparse.Namespace) -> None:
+    try:
+        planned = core.plan_prod_actions(
+            names=args.names or None,
+            repo=args.repo,
+            refresh=False if args.no_refresh else None,
+        )
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(planned, indent=2))
+        return
+
+    if not planned:
+        print("No sessions matched.")
+        return
+
+    matched = 0
+    for action in planned:
+        if action.get("skipped"):
+            print(f"{action['session']}  skipped ({action.get('reason', 'no-rule')})")
+            continue
+
+        matched += 1
+        pr_display = f"#{action['pr']}" if action.get("pr") else "-"
+        header = (
+            f"{action['session']}  rule={action['rule']}  pr={pr_display}"
+            f"  review={action.get('pr_review') or '-'}  merge={action.get('pr_merge_state') or '-'}"
+        )
+        print(header)
+        print(f"  {action['prompt']}")
+
+        if args.dry_run:
+            continue
+
+        wait = args.wait
+        timeout = args.timeout if args.timeout is not None else 30.0
+        try:
+            core.send_text(
+                str(action["session"]),
+                str(action["prompt"]),
+                wait=wait,
+                timeout=timeout,
+            )
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+
+    if matched == 0:
+        print("No prod rules matched.")
+        return
+
+    if args.dry_run:
+        print(f"Planned {matched} prod message(s).")
+    else:
+        print(f"Sent {matched} prod message(s).")
+
+
 def cmd_jump(args: argparse.Namespace) -> None:
     try:
         core.jump_session(args.name)
@@ -839,6 +899,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_send.add_argument("--wait", action="store_true", help="Wait for the agent to become ready before sending")
     p_send.add_argument("--timeout", type=float, default=30.0, help="Seconds to wait with --wait (default: 30)")
 
+    # prod
+    p_prod = sub.add_parser("prod", help="Send configured follow-up prompts based on session/PR state")
+    p_prod.add_argument("names", nargs="*", help="Optional session names to prod")
+    p_prod.add_argument("--repo", help="Filter by repo name (substring match)")
+    p_prod.add_argument("--dry-run", action="store_true", help="Preview resolved prompts without sending")
+    p_prod.add_argument("--json", action="store_true", help="Output resolved actions as JSON")
+    p_prod.add_argument("--no-refresh", action="store_true", help="Use cached metadata instead of refreshing PR state first")
+    p_prod.add_argument("--wait", action="store_true", help="Wait for agent readiness before every send")
+    p_prod.add_argument("--timeout", type=float, help="Override send wait timeout for every matched rule")
+
     # jump
     p_jump = sub.add_parser("jump", help="Attach/switch to a session (fzf picker if no name)")
     p_jump.add_argument("name", nargs="?", default=None, help="Session name")
@@ -927,6 +997,7 @@ def main(argv: list[str] | None = None) -> None:
         "new": cmd_new,
         "peek": cmd_peek,
         "send": cmd_send,
+        "prod": cmd_prod,
         "jump": cmd_jump,
         "status": cmd_status,
         "trace": cmd_trace,

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -59,6 +59,7 @@ NODE_DISAMBIGUATION: dict[str, str] = {
 
 _VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 PROFILE_CONFIG_PATH = Path.home() / ".config" / "tmux-pilot" / "profiles.toml"
+_RESERVED_CONFIG_TABLES = {"prod"}
 _DEFAULT_CLONE_BASE = "~/repos"
 _DEFAULT_WORKTREE_BASE = "~/worktrees"
 _SEND_KEYS_SETTLE_DELAY = 0.1
@@ -117,6 +118,34 @@ class SessionProfile:
             return self.command
         parts = [self.agent.strip(), *shlex.split(self.agent_args)]
         return tuple(part for part in parts if part)
+
+
+@dataclass(frozen=True)
+class ProdRule:
+    """Configured `tp prod` rule."""
+
+    name: str
+    match: dict[str, tuple[str, ...]]
+    prompt: str
+
+
+@dataclass(frozen=True)
+class ProdConfig:
+    """Resolved `tp prod` config."""
+
+    refresh: bool = True
+    rules: tuple[ProdRule, ...] = ()
+
+
+class AgentWaitTimeout(RuntimeError):
+    """Raised when an agent stays busy past the requested wait timeout."""
+
+    def __init__(self, session_name: str, last_state: str) -> None:
+        self.session_name = session_name
+        self.last_state = last_state
+        super().__init__(
+            f"Timed out waiting for session '{session_name}' to become ready (last state: {last_state})"
+        )
 
 
 def _run(
@@ -330,6 +359,28 @@ def list_sessions(
 
         sessions.append(info)
     return sessions
+
+
+def resolve_sessions(
+    *,
+    names: list[str] | None = None,
+    status: str | None = None,
+    repo: str | None = None,
+    process: str | None = None,
+) -> list[SessionInfo]:
+    """Return all sessions or a named subset, preserving the requested order."""
+    sessions = list_sessions(status=status, repo=repo, process=process)
+    if not names:
+        return sessions
+
+    by_name = {session.name: session for session in sessions}
+    missing = [name for name in names if name not in by_name]
+    if missing:
+        if len(missing) == 1:
+            raise RuntimeError(f"Session '{missing[0]}' not found")
+        formatted = ", ".join(f"'{name}'" for name in missing)
+        raise RuntimeError(f"Sessions not found: {formatted}")
+    return [by_name[name] for name in names]
 
 
 def get_metadata(session_name: str, key: str) -> str:
@@ -584,15 +635,18 @@ def _is_inside_tmux() -> bool:
     return "TMUX" in os.environ
 
 
-def _load_profile_tables(config_path: Path) -> dict[str, dict[str, object]]:
+def _load_config_data(config_path: Path) -> dict[str, object]:
     if not config_path.exists():
         return {}
 
     with config_path.open("rb") as handle:
         data = tomllib.load(handle)
 
-    if not isinstance(data, dict):
-        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _load_profile_tables(config_path: Path) -> dict[str, dict[str, object]]:
+    data = _load_config_data(config_path)
 
     if isinstance(data.get("profiles"), dict):
         source = data["profiles"]
@@ -602,7 +656,76 @@ def _load_profile_tables(config_path: Path) -> dict[str, dict[str, object]]:
             tables["default"] = default_values
         return tables
 
-    return {name: values for name, values in data.items() if isinstance(values, dict)}
+    return {
+        name: values
+        for name, values in data.items()
+        if isinstance(values, dict) and name not in _RESERVED_CONFIG_TABLES
+    }
+
+
+def _coerce_config_bool(value: object, *, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise RuntimeError(f"{field_name} in {PROFILE_CONFIG_PATH} must be true or false")
+
+
+def _normalize_prod_match(value: object, *, field_name: str) -> tuple[str, ...]:
+    if isinstance(value, (list, tuple)):
+        parts = tuple(str(item).strip() for item in value if str(item).strip())
+        if parts:
+            return parts
+        raise RuntimeError(f"{field_name} in {PROFILE_CONFIG_PATH} must not be empty")
+    normalized = str(value).strip()
+    if normalized:
+        return (normalized,)
+    raise RuntimeError(f"{field_name} in {PROFILE_CONFIG_PATH} must not be empty")
+
+
+def load_prod_config(path: Path | None = None) -> ProdConfig:
+    """Load configurable `tp prod` rules from TOML."""
+    config_path = path or PROFILE_CONFIG_PATH
+    data = _load_config_data(config_path)
+    prod_data = data.get("prod")
+    if not isinstance(prod_data, dict):
+        return ProdConfig()
+
+    refresh = True
+    if "refresh" in prod_data:
+        refresh = _coerce_config_bool(prod_data["refresh"], field_name="[prod].refresh")
+
+    raw_rules = prod_data.get("rules", [])
+    if not isinstance(raw_rules, list):
+        raise RuntimeError(f"[prod].rules in {config_path} must be an array of tables")
+
+    rules: list[ProdRule] = []
+    for index, raw_rule in enumerate(raw_rules, start=1):
+        if not isinstance(raw_rule, dict):
+            raise RuntimeError(f"[prod].rules[{index}] in {config_path} must be a table")
+
+        prompt = str(raw_rule.get("prompt", "")).strip()
+        if not prompt:
+            raise RuntimeError(f"[prod].rules[{index}] in {config_path} is missing a prompt")
+
+        raw_match = raw_rule.get("match", raw_rule.get("when"))
+        if not isinstance(raw_match, dict) or not raw_match:
+            raise RuntimeError(f"[prod].rules[{index}] in {config_path} must define match criteria")
+
+        match = {
+            str(key): _normalize_prod_match(value, field_name=f"[prod].rules[{index}].match.{key}")
+            for key, value in raw_match.items()
+        }
+        rules.append(
+            ProdRule(
+                name=str(raw_rule.get("name", f"rule-{index}")).strip() or f"rule-{index}",
+                match=match,
+                prompt=prompt,
+            )
+        )
+
+    return ProdConfig(
+        refresh=refresh,
+        rules=tuple(rules),
+    )
 
 
 def _resolve_profile_values(
@@ -1036,6 +1159,87 @@ def _render_profile_value(value: str, context: dict[str, str]) -> str:
         return value.format_map(_TemplateDict(context))
     except ValueError as exc:
         raise RuntimeError(f"Invalid profile template '{value}': {exc}") from exc
+
+
+def _prod_session_context(session: SessionInfo) -> dict[str, str]:
+    """Flatten session state into template/match variables for `tp prod`."""
+    repo_path = session.metadata.get("repo", "")
+    context = {
+        "name": session.name,
+        "session_name": session.name,
+        "process": session.process,
+        "working_dir": session.working_dir,
+        "dir": session.working_dir,
+        "pid": session.pid,
+        "agent_state": session.agent_state,
+        "repo_name": Path(repo_path or session.working_dir or session.name).name,
+    }
+    context.update({key: value for key, value in session.metadata.items() if value})
+    pr = context.get("pr", "")
+    context["pr_display"] = f"#{pr}" if pr else "-"
+    return {key: str(value) for key, value in context.items()}
+
+
+def _prod_rule_matches(rule: ProdRule, context: dict[str, str]) -> bool:
+    """Return True when all match predicates agree with the flattened session context."""
+    for key, expected_values in rule.match.items():
+        actual = context.get(key, "").strip().casefold()
+        if not any(actual == candidate.strip().casefold() for candidate in expected_values):
+            return False
+    return True
+
+
+def plan_prod_actions(
+    *,
+    names: list[str] | None = None,
+    repo: str | None = None,
+    refresh: bool | None = None,
+    config_path: Path | None = None,
+) -> list[dict[str, object]]:
+    """Resolve `tp prod` prompts for sessions, using the first matching configured rule."""
+    config = load_prod_config(config_path)
+    if not config.rules:
+        raise RuntimeError(f"No [prod] rules configured in {config_path or PROFILE_CONFIG_PATH}")
+
+    should_refresh = config.refresh if refresh is None else refresh
+    if should_refresh:
+        from . import reaper
+
+        reaper.refresh_pr_metadata(names=names, repo=repo)
+
+    sessions = resolve_sessions(names=names, repo=repo)
+    actions: list[dict[str, object]] = []
+    for session in sessions:
+        context = _prod_session_context(session)
+        matched_rule: ProdRule | None = None
+        for rule in config.rules:
+            if _prod_rule_matches(rule, context):
+                matched_rule = rule
+                break
+
+        action: dict[str, object] = {
+            "session": session.name,
+            "process": session.process,
+            "branch": context.get("branch", ""),
+            "pr": context.get("pr", "") or None,
+            "pr_state": context.get("pr_state", "") or None,
+            "pr_review": context.get("pr_review", "") or None,
+            "pr_merge_state": context.get("pr_merge_state", "") or None,
+            "skipped": matched_rule is None,
+            "reason": "no-rule" if matched_rule is None else "",
+        }
+        if matched_rule is None:
+            actions.append(action)
+            continue
+
+        action.update(
+            {
+                "rule": matched_rule.name,
+                "prompt": _render_profile_value(matched_rule.prompt, context),
+            }
+        )
+        actions.append(action)
+    return actions
 
 
 def _profile_context(
@@ -1472,8 +1676,8 @@ def wait_until_session_ready(
         if _agent_is_ready(agent):
             return agent
         if time.monotonic() >= deadline:
-            state = agent.get("state", "unknown")
-            raise RuntimeError(f"Timed out waiting for session '{name}' to become ready (last state: {state})")
+            state = str(agent.get("state", "unknown"))
+            raise AgentWaitTimeout(name, state)
         time.sleep(interval)
 
 

--- a/src/tmux_pilot/reaper.py
+++ b/src/tmux_pilot/reaper.py
@@ -47,18 +47,7 @@ def _resolve_sessions(
     repo: str | None = None,
 ) -> list[core.SessionInfo]:
     """Return all sessions or a named subset, preserving the requested order."""
-    sessions = core.list_sessions(repo=repo)
-    if not names:
-        return sessions
-
-    by_name = {session.name: session for session in sessions}
-    missing = [name for name in names if name not in by_name]
-    if missing:
-        if len(missing) == 1:
-            raise RuntimeError(f"Session '{missing[0]}' not found")
-        formatted = ", ".join(f"'{name}'" for name in missing)
-        raise RuntimeError(f"Sessions not found: {formatted}")
-    return [by_name[name] for name in names]
+    return core.resolve_sessions(names=names, repo=repo)
 
 
 def _refresh_session_pr_metadata(session: core.SessionInfo) -> dict:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1597,6 +1597,7 @@ class TestCLI:
         send_keys_calls: list[tuple[str, str]] = []
 
         monkeypatch.setattr(core, "send_keys", lambda name, text: send_keys_calls.append((name, text)))
+        monkeypatch.setattr(core, "set_metadata", lambda *args: None)
 
         def raise_timeout(name: str, text: str, *, wait: bool = False, timeout: float = 30.0, interval: float = 0.25):
             del name, text, wait, timeout, interval

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -920,7 +920,9 @@ class TestCLI:
         with pytest.raises(SystemExit) as exc_info:
             cli_main(["--version"])
         assert exc_info.value.code == 0
-        assert "0.3.0" in capsys.readouterr().out
+        output = capsys.readouterr().out
+        assert output.startswith("tp ")
+        assert "0.0.0" not in output
 
     def test_ls(self, fake_tmux: FakeTmux, capsys):
         cli_main(["ls"])
@@ -1295,6 +1297,111 @@ class TestCLI:
 
         assert exc_info.value.code == 1
         assert "boom" in capsys.readouterr().err
+
+    def test_prod_dry_run(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(
+            core,
+            "plan_prod_actions",
+            lambda **kwargs: [
+                {
+                    "session": TEST_SESSION,
+                    "pr": "1614",
+                    "pr_review": "CHANGES_REQUESTED",
+                    "pr_merge_state": "BLOCKED",
+                    "skipped": False,
+                    "rule": "changes-requested",
+                    "prompt": "Address all requested review comments.",
+                },
+                {
+                    "session": "idle",
+                    "skipped": True,
+                    "reason": "no-rule",
+                },
+            ],
+        )
+        send_calls: list[tuple[str, str, bool, float]] = []
+        monkeypatch.setattr(
+            core,
+            "send_text",
+            lambda name, text, *, wait, timeout, interval=0.25: send_calls.append((name, text, wait, timeout)),
+        )
+
+        cli_main(["prod", "--dry-run", TEST_SESSION, "idle"])
+
+        out = capsys.readouterr().out
+        assert "rule=changes-requested" in out
+        assert "Address all requested review comments." in out
+        assert "idle  skipped (no-rule)" in out
+        assert "Planned 1 prod message(s)." in out
+        assert send_calls == []
+
+    def test_prod_sends_prompts(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(
+            core,
+            "plan_prod_actions",
+            lambda **kwargs: [
+                {
+                    "session": TEST_SESSION,
+                    "pr": "1614",
+                    "pr_review": "CHANGES_REQUESTED",
+                    "pr_merge_state": "BLOCKED",
+                    "skipped": False,
+                    "rule": "changes-requested",
+                    "prompt": "Address all requested review comments.",
+                }
+            ],
+        )
+        send_calls: list[tuple[str, str, bool, float]] = []
+
+        def send_text(name: str, text: str, *, wait: bool, timeout: float, interval: float = 0.25):
+            del interval
+            send_calls.append((name, text, wait, timeout))
+            return {"type": "codex", "state": "completed", "ready": True}
+
+        monkeypatch.setattr(core, "send_text", send_text)
+
+        cli_main(["prod", "--timeout", "12", TEST_SESSION])
+
+        assert send_calls == [(TEST_SESSION, "Address all requested review comments.", False, 12.0)]
+        assert "Sent 1 prod message(s)." in capsys.readouterr().out
+
+    def test_prod_with_wait_keeps_timeout_strict(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(
+            core,
+            "plan_prod_actions",
+            lambda **kwargs: [
+                {
+                    "session": TEST_SESSION,
+                    "pr": "1614",
+                    "pr_review": "CHANGES_REQUESTED",
+                    "pr_merge_state": "DIRTY",
+                    "skipped": False,
+                    "rule": "changes-requested",
+                    "prompt": "Address all requested review comments.",
+                }
+            ],
+        )
+
+        def send_text(name: str, text: str, *, wait: bool, timeout: float, interval: float = 0.25):
+            del name, text, wait, timeout, interval
+            raise core.AgentWaitTimeout(TEST_SESSION, "running")
+
+        monkeypatch.setattr(core, "send_text", send_text)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main(["prod", "--wait", TEST_SESSION])
+
+        assert exc_info.value.code == 1
+        assert "Timed out waiting for session" in capsys.readouterr().err
+
+    def test_prod_reports_config_errors(self, monkeypatch: pytest.MonkeyPatch, capsys):
+        monkeypatch.setattr(core, "plan_prod_actions", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("no rules")))
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main(["prod"])
+
+        assert exc_info.value.code == 1
+        assert "no rules" in capsys.readouterr().err
 
     def test_new_with_agent_and_prompt_uses_plain_mode(self, monkeypatch: pytest.MonkeyPatch, capsys):
         new_calls: list[tuple[str, str | None, str | None]] = []

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -53,6 +53,23 @@ def test_builtin_codex_profile_matches_send_wait_timeout(tmp_path):
     assert profile is not None
     assert profile.prompt_wait_timeout == 30.0
 
+def test_prod_section_is_not_treated_as_a_profile(tmp_path):
+    config = tmp_path / "profiles.toml"
+    config.write_text(
+        """
+[default]
+extends = "codex"
+
+[prod]
+default_wait = true
+"""
+    )
+
+    profiles = core.load_profiles(config)
+
+    assert "default" in profiles
+    assert "prod" not in profiles
+
 
 def test_should_use_profile_mode_applies_default_profile_with_directory(tmp_path):
     config = tmp_path / "profiles.toml"
@@ -64,6 +81,93 @@ command = ["codex", "--profile", "yolo"]
     )
 
     assert core.should_use_profile_mode(directory=str(tmp_path), path=config) is True
+
+
+def test_load_prod_config_parses_rules(tmp_path):
+    config = tmp_path / "profiles.toml"
+    config.write_text(
+        """
+[prod]
+refresh = false
+
+[[prod.rules]]
+name = "changes-requested"
+match = { pr_review = "CHANGES_REQUESTED", pr_state = "OPEN" }
+prompt = "Address all requested changes on {pr_display} for {name}."
+
+[[prod.rules]]
+name = "merge-blocked"
+match = { pr_merge_state = ["BLOCKED", "DIRTY"] }
+prompt = "Unblock mergeability for {branch}."
+"""
+    )
+
+    prod = core.load_prod_config(config)
+
+    assert prod.refresh is False
+    assert len(prod.rules) == 2
+    assert prod.rules[0].match == {
+        "pr_review": ("CHANGES_REQUESTED",),
+        "pr_state": ("OPEN",),
+    }
+    assert prod.rules[1].match == {"pr_merge_state": ("BLOCKED", "DIRTY")}
+
+
+def test_plan_prod_actions_uses_first_matching_rule(tmp_path, monkeypatch):
+    config = tmp_path / "profiles.toml"
+    config.write_text(
+        """
+[prod]
+refresh = false
+
+[[prod.rules]]
+name = "changes-requested"
+match = { pr_review = "CHANGES_REQUESTED" }
+prompt = "Address review feedback on {pr_display} for {name}."
+
+[[prod.rules]]
+name = "open-pr"
+match = { pr_state = "OPEN" }
+prompt = "General follow-up for {name}."
+"""
+    )
+
+    monkeypatch.setattr(
+        core,
+        "resolve_sessions",
+        lambda **kwargs: [
+            core.SessionInfo(
+                name="dragon-assign",
+                process="codex",
+                working_dir="/tmp/dragon-assign",
+                metadata={
+                    "branch": "feat/dragon-ai-assignment-trigger",
+                    "pr": "1614",
+                    "pr_state": "OPEN",
+                    "pr_review": "CHANGES_REQUESTED",
+                    "pr_merge_state": "BLOCKED",
+                },
+            )
+        ],
+    )
+
+    actions = core.plan_prod_actions(config_path=config)
+
+    assert actions == [
+        {
+            "session": "dragon-assign",
+            "process": "codex",
+            "branch": "feat/dragon-ai-assignment-trigger",
+            "pr": "1614",
+            "pr_state": "OPEN",
+            "pr_review": "CHANGES_REQUESTED",
+            "pr_merge_state": "BLOCKED",
+            "skipped": False,
+            "reason": "",
+            "rule": "changes-requested",
+            "prompt": "Address review feedback on #1614 for dragon-assign.",
+        }
+    ]
 
 
 def test_create_profile_session_creates_worktree_launches_agent_and_prompt(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -894,7 +894,6 @@ wheels = [
 
 [[package]]
 name = "tmux-pilot"
-version = "0.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
This PR bundles two related improvements that were sitting together in the local checkout:

- switch package publishing to the same trusted-publisher and git-derived versioning pattern used in `valuesets`
- add configurable `tp prod` rules so session/PR state can drive the next follow-up prompt

## What Changed
- switched `pyproject.toml` to dynamic versioning via `uv-dynamic-versioning`
- updated `tmux_pilot.__version__` to read installed package metadata, with a git-describe fallback for source checkouts
- modernized `.github/workflows/publish.yml` for PyPI trusted publishing with a `release` environment
- added TOML-backed `[prod]` / `[[prod.rules]]` config parsing in `profiles.toml`
- added `tp prod` with repo filters, dry-run output, JSON output, and optional explicit `--wait`
- documented the new release flow and `tp prod` workflow in README and docs
- added tests for dynamic version behavior and prod rule planning / CLI behavior

## Why
The previous publish workflow failed trusted publishing because the repository was not aligned with the newer PyPI OIDC setup, and the package version was still hardcoded in source.

Separately, the PR dashboard metadata became useful enough that the natural next step was a configurable orchestration command: if a session matches a known PR state such as `CHANGES_REQUESTED`, `tp` should be able to render and send the corresponding follow-up prompt directly.

## User Impact
- package releases can follow the trusted-publisher path expected by PyPI
- `tp --version` reflects installed package metadata or git state instead of a stale hardcoded constant
- users can define `tp prod` rules in `~/.config/tmux-pilot/profiles.toml` and turn cached PR metadata into the next message for matching sessions

## Validation
- `pytest -q`
- `uv run --group docs mkdocs build`
