### PR TITLE
[codex] Add tp wt commands

### DIFF
--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -183,6 +183,58 @@ tp install-hooks --uninstall
 
 Use this when you want git lifecycle hooks wired to `tp`'s session cleanup flows.
 
+## Manage Worktrees After A Restart
+
+When tmux sessions are gone (e.g. after a reboot) but your worktrees are still on disk:
+
+### Survey what exists
+
+```bash
+tp wt ls
+tp wt ls --repo dismech
+tp wt ls --orphan --stale 14
+tp wt status
+```
+
+### Check PR state across worktrees
+
+```bash
+tp wt refresh --repo ai-gene-review
+tp wt ls --repo ai-gene-review
+```
+
+### Resume work in a worktree
+
+```bash
+# Jump to existing session, or create a new one with the detected agent
+tp wt resume oauth-fix
+
+# Resume with Claude's --continue flag (picks up last conversation)
+tp wt resume oauth-fix -c
+
+# Override the profile if detection gets it wrong
+tp wt resume oauth-fix --profile codex
+```
+
+### Clean up stale worktrees
+
+```bash
+# Preview what would be removed
+tp wt clean
+
+# Only clean worktrees older than 30 days in one repo
+tp wt clean --repo dismech --stale 30
+
+# Actually remove them
+tp wt clean --force
+```
+
+### Also clean orphan worktrees during session cleanup
+
+```bash
+tp clean --force --include-orphan-worktrees
+```
+
 ## A Good Daily Loop
 
 ```bash

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -18,6 +18,11 @@ This page is the compact command reference for `tp`. For longer walkthroughs, us
 | `tp install-hooks` | install or remove git lifecycle hooks |
 | `tp refresh` | refresh cached PR metadata without cleanup |
 | `tp reap` | remove sessions whose PRs are merged |
+| `tp wt ls` | list worktrees with repo, branch, age, PR, and status |
+| `tp wt status` | worktree health summary by repo and status |
+| `tp wt refresh` | fetch and cache PR metadata for worktrees |
+| `tp wt resume` | resume work in a worktree (jump or create session) |
+| `tp wt clean` | remove merged/orphan+stale worktrees |
 
 ## `tp ls`
 
@@ -186,6 +191,74 @@ tp reap --include-no-pr --dry-run
 ```
 
 `tp reap --dry-run` still refreshes and persists safe PR metadata before deciding what would be reaped.
+
+## `tp wt`
+
+Manage worktrees independently of tmux sessions. Useful after a restart when sessions are gone but worktrees still hold your work.
+
+### `tp wt ls`
+
+```bash
+tp wt ls
+tp wt ls --repo dismech
+tp wt ls --orphan
+tp wt ls --stale 14
+tp wt ls --orphan --stale 14
+tp wt ls --full
+tp wt ls --json
+tp wt ls --cols NAME,REPO,BRANCH,PR,STATUS
+```
+
+Columns: `NAME`, `REPO`, `BRANCH`, `AGE`, `PR`, `SESSION`, `AGENT`, `STATUS`.
+
+Status labels: `active`, `orphan`, `stale`, `orphan+stale`, `merged`, `dirty`.
+
+PR column uses the same compact codes as `tp ls` (`M` merged, `X` closed, `A` approved, `CR` changes requested). Requires `tp wt refresh` to populate.
+
+### `tp wt status`
+
+```bash
+tp wt status
+tp wt status --repo dismech
+tp wt status --json
+```
+
+Shows aggregate counts by repo and by status category.
+
+### `tp wt refresh`
+
+```bash
+tp wt refresh
+tp wt refresh --repo tmux-pilot
+tp wt refresh --json
+```
+
+Fetches PR metadata for each worktree branch via `gh pr list` and caches results to `~/.cache/tmux-pilot/wt-pr-cache.json`. Subsequent `tp wt ls` calls show cached PR data without re-querying GitHub.
+
+### `tp wt resume`
+
+```bash
+tp wt resume oauth-fix
+tp wt resume oauth-fix -c
+tp wt resume oauth-fix --profile codex
+```
+
+Resume work in a worktree:
+
+1. If there is already a tmux session using the worktree, jump to it.
+2. Otherwise, create a new session with the auto-detected agent profile (based on `.claude/` or `.codex` presence) and jump to it.
+
+Use `-c` / `--continue` to pass `--continue` to Claude Code, resuming the most recent conversation in that directory.
+
+### `tp wt clean`
+
+```bash
+tp wt clean
+tp wt clean --force
+tp wt clean --repo dismech --stale 30
+```
+
+Removes worktrees that are merged or (orphan + stale). Dry-run by default; use `--force` to execute.
 
 ## Notes On Current Behavior
 

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -432,15 +432,50 @@ def cmd_wt(args: argparse.Namespace) -> None:
             print(f"\nCleaned {removed}/{len(actions)} worktrees.")
 
     elif wt_cmd == "resume":
-        result = worktree.resume_worktree(
-            args.name,
+        patterns = args.patterns
+        # Single pattern: original behavior (find + jump)
+        if len(patterns) == 1 and not args.dry_run:
+            matches = worktree.find_worktrees(patterns)
+            if len(matches) == 1:
+                result = worktree.resume_worktree(
+                    patterns[0],
+                    profile_override=args.profile,
+                    continue_session=args.continue_session,
+                    jump=True,
+                )
+                if result["action"] == "exists":
+                    print(f"Jumped to existing session: {result['session']}")
+                else:
+                    print(f"Created session: {result['session']} (profile: {result['profile']})")
+                return
+            # Multiple matches for single pattern — fall through to bulk mode
+
+        # Bulk mode: find all matches, show or create
+        matches = worktree.find_worktrees(patterns)
+        if not matches:
+            print(f"No worktrees matching: {' '.join(patterns)}", file=sys.stderr)
+            sys.exit(1)
+
+        if args.dry_run:
+            print(f"Would resume {len(matches)} worktree(s):")
+            for path in matches:
+                print(f"  {Path(path).name}")
+            return
+
+        results = worktree.resume_worktrees(
+            patterns,
             profile_override=args.profile,
             continue_session=args.continue_session,
         )
-        if result["action"] == "jumped":
-            print(f"Jumped to existing session: {result['session']}")
-        else:
-            print(f"Created session: {result['session']} (profile: {result['profile']})")
+        for r in results:
+            action = r["action"]
+            name = r["session"]
+            wt_name = Path(r["worktree"]).name
+            if action == "exists":
+                print(f"  {wt_name}: session already exists ({name})")
+            else:
+                print(f"  {wt_name}: created ({r['profile']})")
+        print(f"\nResumed {len(results)} worktree(s).")
 
     elif wt_cmd == "refresh":
         wts = worktree.scan_worktrees(repo=args.repo)
@@ -602,10 +637,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_wt_clean.add_argument("--stale", type=int, metavar="DAYS", default=7, help="Staleness threshold in days (default: 7)")
 
     # wt resume
-    p_wt_resume = wt_sub.add_parser("resume", help="Resume work in a worktree")
-    p_wt_resume.add_argument("name", help="Worktree name (or substring)")
+    p_wt_resume = wt_sub.add_parser("resume", help="Resume work in worktree(s)")
+    p_wt_resume.add_argument("patterns", nargs="+", help="Worktree name(s), substrings, or regex patterns")
     p_wt_resume.add_argument("-c", "--continue", dest="continue_session", action="store_true", help="Resume last agent conversation (claude --continue)")
     p_wt_resume.add_argument("--profile", help="Override auto-detected profile (claude/codex)")
+    p_wt_resume.add_argument("--dry-run", action="store_true", help="Show what would be resumed without creating sessions")
 
     # wt refresh
     p_wt_refresh = wt_sub.add_parser("refresh", help="Fetch/cache PR status for worktrees")

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -9,7 +9,7 @@ import sys
 
 from pathlib import Path
 
-from . import core, display, hooks
+from . import core, display, hooks, worktree
 
 
 _NEW_DESCRIPTION = """Create a tmux session.
@@ -245,6 +245,14 @@ def cmd_clean(args: argparse.Namespace) -> None:
         print("  ".join(parts))
     print(f"Cleaned {len(actions)} session(s).")
 
+    if args.include_orphan_worktrees:
+        orphan_wts = worktree.scan_worktrees(orphan_only=True, stale_days=7, full=True)
+        wt_actions = worktree.clean_worktrees(orphan_wts, dry_run=args.dry_run)
+        if wt_actions:
+            print(f"\nOrphan worktrees {'(dry run)' if args.dry_run else 'cleaned'}:")
+            for a in wt_actions:
+                print(f"  {Path(a['path']).name} ({a['reason']})")
+
 
 def cmd_set(args: argparse.Namespace) -> None:
     if not core.session_exists(args.name):
@@ -362,6 +370,68 @@ def cmd_refresh(args: argparse.Namespace) -> None:
         )
 
 
+def cmd_wt(args: argparse.Namespace) -> None:
+    wt_cmd = getattr(args, "wt_command", None)
+    if not wt_cmd:
+        # Show help for wt subcommand
+        build_parser().parse_args(["wt", "--help"])
+        return
+
+    if wt_cmd == "ls":
+        wts = worktree.scan_worktrees(
+            repo=args.repo,
+            stale_days=args.stale,
+            orphan_only=args.orphan,
+            full=args.full,
+        )
+        if args.json:
+            print(json.dumps([w.to_dict() for w in wts], indent=2))
+        else:
+            print(display.format_worktree_table(wts, cols=args.cols))
+
+    elif wt_cmd == "status":
+        wts = worktree.scan_worktrees(repo=args.repo, full=args.full)
+        summary = worktree.worktree_summary(wts)
+        if args.json:
+            print(json.dumps(summary, indent=2))
+        else:
+            print(f"Total worktrees: {summary['total']}")
+            print()
+            print("By status:")
+            for status, count in sorted(summary["by_status"].items()):
+                if count:
+                    print(f"  {status}: {count}")
+            print()
+            print("By repo (top 15):")
+            sorted_repos = sorted(summary["by_repo"].items(), key=lambda x: -x[1])
+            for repo_name, count in sorted_repos[:15]:
+                print(f"  {repo_name}: {count}")
+            if len(sorted_repos) > 15:
+                print(f"  ... and {len(sorted_repos) - 15} more")
+
+    elif wt_cmd == "clean":
+        wts = worktree.scan_worktrees(
+            repo=args.repo,
+            stale_days=args.stale,
+            full=True,  # Need merged status for cleanup
+        )
+        actions = worktree.clean_worktrees(wts, dry_run=not args.force)
+        if not actions:
+            print("No worktrees to clean.")
+            return
+        if not args.force:
+            print("Dry run — would clean:")
+            for a in actions:
+                print(f"  {Path(a['path']).name} ({a['reason']})")
+            print(f"\nUse --force to execute. ({len(actions)} worktrees)")
+        else:
+            for a in actions:
+                status = "removed" if a["removed"] else "FAILED"
+                print(f"  {Path(a['path']).name}: {status}")
+            removed = sum(1 for a in actions if a["removed"])
+            print(f"\nCleaned {removed}/{len(actions)} worktrees.")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tp",
@@ -447,6 +517,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_clean.add_argument("--status", help="Filter by status (default: done/complete/finished/merged)")
     p_clean.add_argument("--dry-run", action="store_true", help="Preview without executing")
     p_clean.add_argument("--force", action="store_true", help="Skip confirmation prompt")
+    p_clean.add_argument("--include-orphan-worktrees", action="store_true", help="Also clean orphaned worktrees")
 
     # kill
     p_kill = sub.add_parser("kill", help="Kill a session")
@@ -480,6 +551,31 @@ def build_parser() -> argparse.ArgumentParser:
     p_refresh.add_argument("--repo", help="Filter by repo name (substring match)")
     p_refresh.add_argument("--json", action="store_true", help="Output refreshed state as JSON")
 
+    # wt (worktree management)
+    p_wt = sub.add_parser("wt", help="Manage worktrees")
+    wt_sub = p_wt.add_subparsers(dest="wt_command")
+
+    # wt ls
+    p_wt_ls = wt_sub.add_parser("ls", help="List worktrees")
+    p_wt_ls.add_argument("--repo", help="Filter by repo name")
+    p_wt_ls.add_argument("--stale", type=int, metavar="DAYS", help="Only show worktrees older than N days")
+    p_wt_ls.add_argument("--orphan", action="store_true", help="Only show orphaned worktrees (no active session)")
+    p_wt_ls.add_argument("--json", action="store_true", help="JSON output")
+    p_wt_ls.add_argument("--cols", help="Columns to display")
+    p_wt_ls.add_argument("--full", action="store_true", help="Include merged/unpushed checks (slower)")
+
+    # wt status
+    p_wt_status = wt_sub.add_parser("status", help="Worktree health summary")
+    p_wt_status.add_argument("--repo", help="Filter by repo name")
+    p_wt_status.add_argument("--json", action="store_true", help="JSON output")
+    p_wt_status.add_argument("--full", action="store_true", help="Include merged/unpushed checks (slower)")
+
+    # wt clean
+    p_wt_clean = wt_sub.add_parser("clean", help="Remove stale/merged/orphaned worktrees")
+    p_wt_clean.add_argument("--force", action="store_true", help="Actually delete (default is dry-run)")
+    p_wt_clean.add_argument("--repo", help="Filter by repo name")
+    p_wt_clean.add_argument("--stale", type=int, metavar="DAYS", default=7, help="Staleness threshold in days (default: 7)")
+
     return parser
 
 
@@ -510,6 +606,7 @@ def main(argv: list[str] | None = None) -> None:
         "install-hooks": cmd_install_hooks,
         "reap": cmd_reap,
         "refresh": cmd_refresh,
+        "wt": cmd_wt,
     }
     handlers[args.command](args)
 

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -431,6 +431,31 @@ def cmd_wt(args: argparse.Namespace) -> None:
             removed = sum(1 for a in actions if a["removed"])
             print(f"\nCleaned {removed}/{len(actions)} worktrees.")
 
+    elif wt_cmd == "resume":
+        result = worktree.resume_worktree(
+            args.name,
+            profile_override=args.profile,
+            continue_session=args.continue_session,
+        )
+        if result["action"] == "jumped":
+            print(f"Jumped to existing session: {result['session']}")
+        else:
+            print(f"Created session: {result['session']} (profile: {result['profile']})")
+
+    elif wt_cmd == "refresh":
+        wts = worktree.scan_worktrees(repo=args.repo)
+        results = worktree.refresh_worktree_prs(wts)
+        if getattr(args, "json", False):
+            print(json.dumps(results, indent=2))
+        else:
+            found = sum(1 for r in results if r.get("pr"))
+            print(f"Refreshed {len(results)} worktrees, {found} with PRs.")
+            for r in results:
+                if r.get("pr"):
+                    pr = r["pr"]
+                    name = Path(r["path"]).name
+                    print(f"  {name}: #{pr['number']} ({pr['state']}) review={pr['review']}")
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -575,6 +600,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_wt_clean.add_argument("--force", action="store_true", help="Actually delete (default is dry-run)")
     p_wt_clean.add_argument("--repo", help="Filter by repo name")
     p_wt_clean.add_argument("--stale", type=int, metavar="DAYS", default=7, help="Staleness threshold in days (default: 7)")
+
+    # wt resume
+    p_wt_resume = wt_sub.add_parser("resume", help="Resume work in a worktree")
+    p_wt_resume.add_argument("name", help="Worktree name (or substring)")
+    p_wt_resume.add_argument("-c", "--continue", dest="continue_session", action="store_true", help="Resume last agent conversation (claude --continue)")
+    p_wt_resume.add_argument("--profile", help="Override auto-detected profile (claude/codex)")
+
+    # wt refresh
+    p_wt_refresh = wt_sub.add_parser("refresh", help="Fetch/cache PR status for worktrees")
+    p_wt_refresh.add_argument("--repo", help="Filter by repo name")
+    p_wt_refresh.add_argument("--json", action="store_true", help="JSON output")
 
     return parser
 

--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -432,28 +432,9 @@ def cmd_wt(args: argparse.Namespace) -> None:
             print(f"\nCleaned {removed}/{len(actions)} worktrees.")
 
     elif wt_cmd == "resume":
-        patterns = args.patterns
-        # Single pattern: original behavior (find + jump)
-        if len(patterns) == 1 and not args.dry_run:
-            matches = worktree.find_worktrees(patterns)
-            if len(matches) == 1:
-                result = worktree.resume_worktree(
-                    patterns[0],
-                    profile_override=args.profile,
-                    continue_session=args.continue_session,
-                    jump=True,
-                )
-                if result["action"] == "exists":
-                    print(f"Jumped to existing session: {result['session']}")
-                else:
-                    print(f"Created session: {result['session']} (profile: {result['profile']})")
-                return
-            # Multiple matches for single pattern — fall through to bulk mode
-
-        # Bulk mode: find all matches, show or create
-        matches = worktree.find_worktrees(patterns)
+        matches = worktree.find_worktrees(args.patterns)
         if not matches:
-            print(f"No worktrees matching: {' '.join(patterns)}", file=sys.stderr)
+            print(f"No worktrees matching: {' '.join(args.patterns)}", file=sys.stderr)
             sys.exit(1)
 
         if args.dry_run:
@@ -462,20 +443,28 @@ def cmd_wt(args: argparse.Namespace) -> None:
                 print(f"  {Path(path).name}")
             return
 
+        jump = args.jump
+        if jump and len(matches) > 1:
+            print("--jump requires a single worktree match, but got "
+                  f"{len(matches)}. Use --dry-run to preview.", file=sys.stderr)
+            sys.exit(1)
+
         results = worktree.resume_worktrees(
-            patterns,
+            args.patterns,
             profile_override=args.profile,
             continue_session=args.continue_session,
+            no_agent=args.no_agent,
+            jump=jump,
         )
         for r in results:
-            action = r["action"]
-            name = r["session"]
             wt_name = Path(r["worktree"]).name
-            if action == "exists":
-                print(f"  {wt_name}: session already exists ({name})")
+            if r["action"] == "exists":
+                suffix = " (jumped)" if jump else ""
+                print(f"  {wt_name}: session already exists ({r['session']}){suffix}")
             else:
-                print(f"  {wt_name}: created ({r['profile']})")
-        print(f"\nResumed {len(results)} worktree(s).")
+                print(f"  {wt_name}: created ({r.get('profile', 'shell')})")
+        if len(results) > 1:
+            print(f"\nResumed {len(results)} worktree(s).")
 
     elif wt_cmd == "refresh":
         wts = worktree.scan_worktrees(repo=args.repo)
@@ -639,7 +628,9 @@ def build_parser() -> argparse.ArgumentParser:
     # wt resume
     p_wt_resume = wt_sub.add_parser("resume", help="Resume work in worktree(s)")
     p_wt_resume.add_argument("patterns", nargs="+", help="Worktree name(s), substrings, or regex patterns")
-    p_wt_resume.add_argument("-c", "--continue", dest="continue_session", action="store_true", help="Resume last agent conversation (claude --continue)")
+    p_wt_resume.add_argument("-c", "--continue", dest="continue_session", action="store_true", help="Pass --continue to agent (resume last conversation)")
+    p_wt_resume.add_argument("-j", "--jump", action="store_true", help="Attach to the session (single worktree only)")
+    p_wt_resume.add_argument("--no-agent", action="store_true", help="Open shell only, don't launch agent")
     p_wt_resume.add_argument("--profile", help="Override auto-detected profile (claude/codex)")
     p_wt_resume.add_argument("--dry-run", action="store_true", help="Show what would be resumed without creating sessions")
 

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -1299,8 +1299,31 @@ def _is_git_worktree(path: str) -> bool:
 
 def _remove_worktree(path: str) -> bool:
     """Remove a git worktree. Returns True if removed."""
-    result = _run(["git", "worktree", "remove", "--force", path], check=False, timeout=10)
+    # Must run from the parent repo that owns the worktree
+    repo_dir = _worktree_parent_repo(path)
+    if not repo_dir:
+        return False
+    result = _run(
+        ["git", "worktree", "remove", "--force", path],
+        check=False, timeout=60, cwd=repo_dir,
+    )
     return result.returncode == 0
+
+
+def _worktree_parent_repo(wt_path: str) -> str | None:
+    """Derive the parent repo directory from a worktree's .git file."""
+    git_file = Path(wt_path) / ".git"
+    if git_file.is_file():
+        content = git_file.read_text().strip()
+        if content.startswith("gitdir:"):
+            gitdir = content[len("gitdir:"):].strip()
+            # e.g. /Users/x/repos/myrepo/.git/worktrees/branch-name
+            parts = Path(gitdir).parts
+            if ".git" in parts:
+                git_idx = len(parts) - 1 - list(reversed(parts)).index(".git")
+                repo_root = str(Path(*parts[:git_idx])) if git_idx > 0 else "/"
+                return repo_root
+    return None
 
 
 def _is_branch_merged(path: str, branch: str) -> bool:

--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -1398,3 +1398,28 @@ def get_session_status(name: str) -> dict:
         "scrollback_tail": scrollback,
         "agent": agent,
     }
+
+
+# ---------------------------------------------------------------------------
+# Public wrappers for worktree operations
+# ---------------------------------------------------------------------------
+
+
+def is_git_worktree(path: str) -> bool:
+    """Public wrapper: check if path is a git worktree."""
+    return _is_git_worktree(path)
+
+
+def remove_worktree(path: str) -> bool:
+    """Public wrapper: remove a git worktree."""
+    return _remove_worktree(path)
+
+
+def is_branch_merged(path: str, branch: str) -> bool:
+    """Public wrapper: check if branch is merged."""
+    return _is_branch_merged(path, branch)
+
+
+def delete_branch(path: str, branch: str) -> bool:
+    """Public wrapper: delete a local branch."""
+    return _delete_branch(path, branch)

--- a/src/tmux_pilot/display.py
+++ b/src/tmux_pilot/display.py
@@ -323,12 +323,13 @@ WT_COLUMNS: list[tuple[str, str, WtColumnAccessor]] = [
     ("REPO", "R", lambda w: w.repo_name),
     ("BRANCH", "B", lambda w: w.branch or "-"),
     ("AGE", "A", lambda w: _format_age(w.age_days)),
+    ("PR", "P", lambda w: _wt_pr_label(w)),
     ("SESSION", "S", lambda w: w.session_name or "-"),
     ("AGENT", "G", lambda w: w.agent_type),
     ("STATUS", "T", lambda w: _wt_status_label(w)),
 ]
 
-DEFAULT_WT_COLS = "NAME,REPO,BRANCH,AGE,SESSION,AGENT,STATUS"
+DEFAULT_WT_COLS = "NAME,REPO,BRANCH,AGE,PR,SESSION,AGENT,STATUS"
 
 
 def _format_age(days: float) -> str:
@@ -339,6 +340,26 @@ def _format_age(days: float) -> str:
     if days < 30:
         return f"{int(days)}d"
     return f"{int(days // 30)}mo"
+
+
+def _wt_pr_label(w: WorktreeInfo) -> str:
+    from .worktree import get_cached_pr
+    pr = get_cached_pr(w.path)
+    if not pr:
+        return "-"
+    num = pr["number"]
+    state = pr["state"]
+    if state == "MERGED":
+        return f"#{num} M"
+    if state == "CLOSED":
+        return f"#{num} X"
+    review = pr.get("review", "")
+    code = ""
+    if review == "APPROVED":
+        code = " A"
+    elif review == "CHANGES_REQUESTED":
+        code = " CR"
+    return f"#{num}{code}"
 
 
 def _wt_status_label(w: WorktreeInfo) -> str:

--- a/src/tmux_pilot/display.py
+++ b/src/tmux_pilot/display.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timezone
+from pathlib import Path
 
 from .core import SessionInfo
 
@@ -307,3 +308,99 @@ def _parse_iso_timestamp(value: str) -> datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Worktree table formatting
+# ---------------------------------------------------------------------------
+
+from .worktree import WorktreeInfo
+
+WtColumnAccessor = Callable[[WorktreeInfo], str]
+
+WT_COLUMNS: list[tuple[str, str, WtColumnAccessor]] = [
+    ("NAME", "N", lambda w: Path(w.path).name),
+    ("REPO", "R", lambda w: w.repo_name),
+    ("BRANCH", "B", lambda w: w.branch or "-"),
+    ("AGE", "A", lambda w: _format_age(w.age_days)),
+    ("SESSION", "S", lambda w: w.session_name or "-"),
+    ("AGENT", "G", lambda w: w.agent_type),
+    ("STATUS", "T", lambda w: _wt_status_label(w)),
+]
+
+DEFAULT_WT_COLS = "NAME,REPO,BRANCH,AGE,SESSION,AGENT,STATUS"
+
+
+def _format_age(days: float) -> str:
+    if days >= 999:
+        return "?"
+    if days < 1:
+        return "<1d"
+    if days < 30:
+        return f"{int(days)}d"
+    return f"{int(days // 30)}mo"
+
+
+def _wt_status_label(w: WorktreeInfo) -> str:
+    if w.is_merged:
+        return "merged"
+    if w.has_uncommitted:
+        return "dirty"
+    if w.is_orphan and w.is_stale:
+        return "orphan+stale"
+    if w.is_orphan:
+        return "orphan"
+    if w.is_stale:
+        return "stale"
+    return "active"
+
+
+def format_worktree_table(worktrees: list[WorktreeInfo], cols: str | None = None) -> str:
+    """Format worktrees as an aligned table."""
+    if not worktrees:
+        return "No worktrees found."
+
+    columns = _resolve_wt_columns(cols)
+    headers = [name for name, _ in columns]
+    accessors = [acc for _, acc in columns]
+    rows = [[acc(w) for acc in accessors] for w in worktrees]
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    lines = []
+    header_line = "  ".join(h.ljust(widths[i]) for i, h in enumerate(headers))
+    lines.append(header_line)
+    lines.append("  ".join("-" * w for w in widths))
+    for row in rows:
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)))
+
+    return "\n".join(lines)
+
+
+def _resolve_wt_columns(spec: str | None) -> list[tuple[str, WtColumnAccessor]]:
+    if not spec:
+        spec = DEFAULT_WT_COLS
+
+    _wt_col_by_name = {name: (name, acc) for name, _, acc in WT_COLUMNS}
+
+    if "," in spec:
+        result = []
+        for token in spec.split(","):
+            token = token.strip().upper()
+            if token in _wt_col_by_name:
+                result.append(_wt_col_by_name[token])
+            else:
+                raise ValueError(f"Unknown worktree column: {token}")
+        return result
+
+    _wt_col_by_mnemonic = {m: (name, acc) for name, m, acc in WT_COLUMNS}
+    result = []
+    for ch in spec.upper():
+        if ch in _wt_col_by_mnemonic:
+            result.append(_wt_col_by_mnemonic[ch])
+        else:
+            raise ValueError(f"Unknown worktree column mnemonic: {ch}")
+    return result

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -389,18 +389,20 @@ def resume_worktree(
     base: str = _DEFAULT_WORKTREE_BASE,
     profile_override: str | None = None,
     continue_session: bool = False,
-    jump: bool = True,
+    no_agent: bool = False,
+    jump: bool = False,
 ) -> dict:
-    """Resume work in a single worktree - jump to existing session or create new one.
+    """Resume work in a single worktree.
 
-    Returns dict with action taken: {"action": "jumped"|"created"|"exists", ...}
+    Returns dict with action taken: {"action": "exists"|"created", ...}
     """
     wt_path = find_worktree(name, base=base)
     if not wt_path:
         raise RuntimeError(f"No worktree matching '{name}' found in {base}")
 
     return _resume_one(wt_path, profile_override=profile_override,
-                       continue_session=continue_session, jump=jump)
+                       continue_session=continue_session,
+                       no_agent=no_agent, jump=jump)
 
 
 def resume_worktrees(
@@ -409,10 +411,11 @@ def resume_worktrees(
     base: str = _DEFAULT_WORKTREE_BASE,
     profile_override: str | None = None,
     continue_session: bool = False,
+    no_agent: bool = False,
+    jump: bool = False,
 ) -> list[dict]:
     """Resume work in multiple worktrees matching patterns.
 
-    Creates sessions for all matching worktrees (does not jump).
     Returns list of action dicts.
     """
     paths = find_worktrees(patterns, base=base)
@@ -422,7 +425,8 @@ def resume_worktrees(
     results = []
     for wt_path in paths:
         result = _resume_one(wt_path, profile_override=profile_override,
-                             continue_session=continue_session, jump=False)
+                             continue_session=continue_session,
+                             no_agent=no_agent, jump=jump)
         results.append(result)
     return results
 
@@ -432,10 +436,14 @@ def _resume_one(
     *,
     profile_override: str | None = None,
     continue_session: bool = False,
-    jump: bool = True,
+    no_agent: bool = False,
+    jump: bool = False,
 ) -> dict:
     """Resume a single worktree path."""
-    from .core import session_exists, uniqueify_session_name, create_profile_session, jump_session
+    from .core import (
+        session_exists, uniqueify_session_name,
+        create_profile_session, new_session, jump_session,
+    )
 
     # Check if there's already a session using this worktree
     sessions = list_sessions()
@@ -444,6 +452,17 @@ def _resume_one(
             if jump:
                 jump_session(s.name)
             return {"action": "exists", "session": s.name, "worktree": wt_path}
+
+    # Session name = worktree basename
+    session_name = os.path.basename(wt_path)
+    if session_exists(session_name):
+        session_name = uniqueify_session_name(session_name)
+
+    if no_agent:
+        new_session(session_name, directory=wt_path)
+        if jump:
+            jump_session(session_name)
+        return {"action": "created", "session": session_name, "worktree": wt_path, "profile": "shell"}
 
     # Detect profile from branch name
     profile_name = profile_override
@@ -456,19 +475,13 @@ def _resume_one(
         else:
             profile_name = "claude"
 
-    # Build agent override command if --continue
-    # Appends --continue to the profile's configured command rather than hardcoding
+    # Build agent override if --continue: append to profile's configured command
     agent_override = None
-    if continue_session and profile_name in ("claude", "codex"):
+    if continue_session:
         from .core import resolve_session_profile
         profile = resolve_session_profile(profile_name)
         if profile and profile.command_parts:
             agent_override = " ".join(profile.command_parts) + " --continue"
-
-    # Session name = worktree basename
-    session_name = os.path.basename(wt_path)
-    if session_exists(session_name):
-        session_name = uniqueify_session_name(session_name)
 
     create_profile_session(
         session_name,

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -435,14 +435,14 @@ def _resume_one(
     jump: bool = True,
 ) -> dict:
     """Resume a single worktree path."""
-    from .core import session_exists, uniqueify_session_name, create_profile_session, jump_to_session
+    from .core import session_exists, uniqueify_session_name, create_profile_session, jump_session
 
     # Check if there's already a session using this worktree
     sessions = list_sessions()
     for s in sessions:
         if s.working_dir == wt_path:
             if jump:
-                jump_to_session(s.name)
+                jump_session(s.name)
             return {"action": "exists", "session": s.name, "worktree": wt_path}
 
     # Detect profile from branch name
@@ -474,7 +474,7 @@ def _resume_one(
     )
 
     if jump:
-        jump_to_session(session_name)
+        jump_session(session_name)
     return {"action": "created", "session": session_name, "worktree": wt_path, "profile": profile_name}
 
 

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -1,0 +1,300 @@
+"""Worktree scanning, summarisation, and cleanup."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .core import (
+    SessionInfo,
+    is_branch_merged,
+    list_sessions,
+    remove_worktree,
+    delete_branch,
+)
+
+_DEFAULT_WORKTREE_BASE = "~/worktrees"
+
+
+def _run_git(args: list[str], *, cwd: str | None = None, timeout: int = 10) -> subprocess.CompletedProcess:
+    """Run a git command, returning CompletedProcess. Never raises on failure."""
+    try:
+        return subprocess.run(
+            args, capture_output=True, text=True, check=False, cwd=cwd, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(args, returncode=1, stdout="", stderr="timeout")
+
+
+@dataclass
+class WorktreeInfo:
+    """Information about a single git worktree directory."""
+
+    path: str
+    repo_name: str
+    branch: str
+    last_commit_date: datetime | None
+    age_days: float
+    has_session: bool
+    session_name: str | None
+    agent_type: str  # "claude" | "codex" | "unknown"
+    is_merged: bool
+    has_unpushed: bool
+    has_uncommitted: bool
+
+    @property
+    def is_orphan(self) -> bool:
+        """True if no tmux session is using this worktree."""
+        return not self.has_session
+
+    @property
+    def is_stale(self) -> bool:
+        """True if last commit is older than 7 days."""
+        return self.age_days > 7
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict."""
+        return {
+            "path": self.path,
+            "repo_name": self.repo_name,
+            "branch": self.branch,
+            "last_commit_date": self.last_commit_date.isoformat() if self.last_commit_date else None,
+            "age_days": round(self.age_days, 1),
+            "has_session": self.has_session,
+            "session_name": self.session_name,
+            "agent_type": self.agent_type,
+            "is_merged": self.is_merged,
+            "has_unpushed": self.has_unpushed,
+            "has_uncommitted": self.has_uncommitted,
+            "is_orphan": self.is_orphan,
+            "is_stale": self.is_stale,
+        }
+
+
+def _detect_agent_type(wt_path: str) -> str:
+    """Detect agent type from directory contents."""
+    if os.path.isdir(os.path.join(wt_path, ".claude")):
+        return "claude"
+    if os.path.isfile(os.path.join(wt_path, ".codex")):
+        return "codex"
+    return "unknown"
+
+
+def _read_repo_name(wt_path: str) -> str:
+    """Extract repo name from .git file gitdir pointer."""
+    git_path = os.path.join(wt_path, ".git")
+    if os.path.isfile(git_path):
+        content = Path(git_path).read_text().strip()
+        # Format: "gitdir: /path/to/repo/.git/worktrees/branch-name"
+        if content.startswith("gitdir:"):
+            gitdir = content[len("gitdir:"):].strip()
+            # Walk up from .git/worktrees/X to get the repo root
+            parts = Path(gitdir).parts
+            if ".git" in parts:
+                git_idx = len(parts) - 1 - list(reversed(parts)).index(".git")
+                repo_root = Path(*parts[:git_idx]) if git_idx > 0 else Path("/")
+                return repo_root.name
+    return os.path.basename(wt_path)
+
+
+def _probe_worktree(wt_path: str, *, full: bool = False) -> dict:
+    """Gather git info for a single worktree directory."""
+    result: dict = {"path": wt_path}
+
+    # Branch
+    r = _run_git(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=wt_path, timeout=5)
+    result["branch"] = r.stdout.strip() if r.returncode == 0 else ""
+
+    # Last commit date
+    r = _run_git(["git", "log", "-1", "--format=%aI"], cwd=wt_path, timeout=5)
+    if r.returncode == 0 and r.stdout.strip():
+        try:
+            result["last_commit_date"] = datetime.fromisoformat(r.stdout.strip())
+        except ValueError:
+            result["last_commit_date"] = None
+    else:
+        result["last_commit_date"] = None
+
+    # Uncommitted changes
+    r = _run_git(["git", "status", "--porcelain"], cwd=wt_path, timeout=5)
+    result["has_uncommitted"] = r.returncode == 0 and bool(r.stdout.strip())
+
+    # Full mode: merged and unpushed checks
+    if full:
+        branch = result["branch"]
+        if branch:
+            r = _run_git(
+                ["git", "branch", "--merged", "HEAD", "--list", branch],
+                cwd=wt_path, timeout=5,
+            )
+            result["is_merged"] = r.returncode == 0 and branch in (r.stdout or "")
+
+            r = _run_git(["git", "log", "@{u}..HEAD", "--oneline"], cwd=wt_path, timeout=5)
+            result["has_unpushed"] = r.returncode == 0 and bool(r.stdout.strip())
+        else:
+            result["is_merged"] = False
+            result["has_unpushed"] = False
+    else:
+        result["is_merged"] = False
+        result["has_unpushed"] = False
+
+    return result
+
+
+def scan_worktrees(
+    base: str = _DEFAULT_WORKTREE_BASE,
+    *,
+    repo: str | None = None,
+    stale_days: int | None = None,
+    orphan_only: bool = False,
+    full: bool = False,
+) -> list[WorktreeInfo]:
+    """Scan worktree directories and return structured info.
+
+    Args:
+        base: Base directory containing worktrees (default ~/worktrees).
+        repo: Filter to worktrees belonging to this repo name.
+        stale_days: If set, only return worktrees older than this many days.
+        orphan_only: If True, only return worktrees with no tmux session.
+        full: If True, also check merged/unpushed status (slower).
+    """
+    base_expanded = os.path.expanduser(base)
+    if not os.path.isdir(base_expanded):
+        return []
+
+    # Phase 1: Scan directories
+    candidates: list[tuple[str, str, str]] = []  # (path, repo_name, agent_type)
+    with os.scandir(base_expanded) as entries:
+        for entry in entries:
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            wt_path = entry.path
+            # Must have a .git file (worktree indicator)
+            git_file = os.path.join(wt_path, ".git")
+            if not os.path.exists(git_file):
+                continue
+            repo_name = _read_repo_name(wt_path)
+            if repo and repo_name != repo:
+                continue
+            agent_type = _detect_agent_type(wt_path)
+            candidates.append((wt_path, repo_name, agent_type))
+
+    if not candidates:
+        return []
+
+    # Phase 2: Parallel git queries
+    def _probe(item: tuple[str, str, str]) -> dict:
+        wt_path, repo_name, agent_type = item
+        info = _probe_worktree(wt_path, full=full)
+        info["repo_name"] = repo_name
+        info["agent_type"] = agent_type
+        return info
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        probed = list(pool.map(_probe, candidates))
+
+    # Phase 3: Cross-reference with tmux sessions
+    sessions = list_sessions()
+    session_by_dir: dict[str, SessionInfo] = {}
+    for s in sessions:
+        if s.working_dir:
+            session_by_dir[s.working_dir] = s
+
+    now = datetime.now(timezone.utc)
+    results: list[WorktreeInfo] = []
+
+    for info in probed:
+        wt_path = info["path"]
+        session = session_by_dir.get(wt_path)
+
+        last_commit_date = info["last_commit_date"]
+        if last_commit_date:
+            if last_commit_date.tzinfo is None:
+                last_commit_date = last_commit_date.replace(tzinfo=timezone.utc)
+            age_days = (now - last_commit_date).total_seconds() / 86400
+        else:
+            age_days = 999.0  # Unknown age treated as very old
+
+        wt = WorktreeInfo(
+            path=wt_path,
+            repo_name=info["repo_name"],
+            branch=info["branch"],
+            last_commit_date=last_commit_date,
+            age_days=age_days,
+            has_session=session is not None,
+            session_name=session.name if session else None,
+            agent_type=info["agent_type"],
+            is_merged=info["is_merged"],
+            has_unpushed=info["has_unpushed"],
+            has_uncommitted=info["has_uncommitted"],
+        )
+
+        # Apply filters
+        if orphan_only and not wt.is_orphan:
+            continue
+        if stale_days is not None and wt.age_days <= stale_days:
+            continue
+
+        results.append(wt)
+
+    return results
+
+
+def worktree_summary(worktrees: list[WorktreeInfo]) -> dict:
+    """Return counts by repo and by status category."""
+    by_repo: dict[str, int] = {}
+    categories = {"orphan": 0, "stale": 0, "active": 0, "merged": 0}
+
+    for wt in worktrees:
+        by_repo[wt.repo_name] = by_repo.get(wt.repo_name, 0) + 1
+        if wt.is_merged:
+            categories["merged"] += 1
+        elif wt.is_orphan:
+            categories["orphan"] += 1
+        elif wt.is_stale:
+            categories["stale"] += 1
+        else:
+            categories["active"] += 1
+
+    return {
+        "total": len(worktrees),
+        "by_repo": by_repo,
+        "by_status": categories,
+    }
+
+
+def clean_worktrees(worktrees: list[WorktreeInfo], *, dry_run: bool = True) -> list[dict]:
+    """Remove worktrees that are merged OR (orphan AND stale).
+
+    Uses remove_worktree() and delete_branch() from core.
+    Returns action dicts describing what was done.
+    """
+    actions: list[dict] = []
+
+    for wt in worktrees:
+        should_clean = wt.is_merged or (wt.is_orphan and wt.is_stale)
+        if not should_clean:
+            continue
+
+        action: dict = {
+            "path": wt.path,
+            "branch": wt.branch,
+            "repo_name": wt.repo_name,
+            "reason": "merged" if wt.is_merged else "orphan+stale",
+            "removed": False,
+            "branch_deleted": False,
+            "dry_run": dry_run,
+        }
+
+        if not dry_run:
+            action["removed"] = remove_worktree(wt.path)
+            if wt.branch and wt.branch not in ("main", "master"):
+                action["branch_deleted"] = delete_branch(wt.path, wt.branch)
+
+        actions.append(action)
+
+    return actions

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json as _json
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
@@ -265,6 +266,164 @@ def worktree_summary(worktrees: list[WorktreeInfo]) -> dict:
         "by_repo": by_repo,
         "by_status": categories,
     }
+
+
+_PR_CACHE_PATH = Path.home() / ".cache" / "tmux-pilot" / "wt-pr-cache.json"
+
+
+def _load_pr_cache() -> dict[str, dict]:
+    """Load PR cache from disk."""
+    if _PR_CACHE_PATH.is_file():
+        return _json.loads(_PR_CACHE_PATH.read_text())
+    return {}
+
+
+def _save_pr_cache(cache: dict[str, dict]) -> None:
+    """Save PR cache to disk."""
+    _PR_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _PR_CACHE_PATH.write_text(_json.dumps(cache, indent=2))
+
+
+def get_cached_pr(wt_path: str) -> dict | None:
+    """Get cached PR info for a worktree path."""
+    cache = _load_pr_cache()
+    entry = cache.get(wt_path)
+    if entry:
+        return entry.get("pr")
+    return None
+
+
+def find_worktree(name: str, base: str = _DEFAULT_WORKTREE_BASE) -> str | None:
+    """Find a worktree by name (exact basename match or substring)."""
+    base_expanded = os.path.expanduser(base)
+    if not os.path.isdir(base_expanded):
+        return None
+    exact = os.path.join(base_expanded, name)
+    if os.path.isdir(exact):
+        return exact
+    # Substring match
+    matches = []
+    with os.scandir(base_expanded) as entries:
+        for entry in entries:
+            if entry.is_dir() and name in entry.name:
+                matches.append(entry.path)
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def resume_worktree(
+    name: str,
+    *,
+    base: str = _DEFAULT_WORKTREE_BASE,
+    profile_override: str | None = None,
+    continue_session: bool = False,
+) -> dict:
+    """Resume work in a worktree - jump to existing session or create new one.
+
+    Returns dict with action taken: {"action": "jumped"|"created", "session": name, ...}
+    """
+    wt_path = find_worktree(name, base=base)
+    if not wt_path:
+        raise RuntimeError(f"No worktree matching '{name}' found in {base}")
+
+    # Check if there's already a session using this worktree
+    sessions = list_sessions()
+    for s in sessions:
+        if s.working_dir == wt_path:
+            from .core import jump_to_session
+            jump_to_session(s.name)
+            return {"action": "jumped", "session": s.name, "worktree": wt_path}
+
+    # Detect profile
+    profile_name = profile_override
+    if not profile_name:
+        agent_type = _detect_agent_type(wt_path)
+        if agent_type == "claude":
+            profile_name = "claude"
+        elif agent_type == "codex":
+            profile_name = "codex"
+        else:
+            profile_name = "claude"  # default fallback
+
+    # Build agent override command if --continue
+    agent_override = None
+    if continue_session and profile_name == "claude":
+        agent_override = "claude --continue --permission-mode bypassPermissions"
+    elif continue_session and profile_name == "codex":
+        agent_override = None  # codex doesn't have --continue
+
+    # Session name = worktree basename
+    session_name = os.path.basename(wt_path)
+    from .core import session_exists, uniqueify_session_name, create_profile_session, jump_to_session
+    if session_exists(session_name):
+        session_name = uniqueify_session_name(session_name)
+
+    create_profile_session(
+        session_name,
+        profile_name=profile_name,
+        agent=agent_override,
+        directory=wt_path,
+    )
+
+    jump_to_session(session_name)
+    return {"action": "created", "session": session_name, "worktree": wt_path, "profile": profile_name}
+
+
+def refresh_worktree_prs(
+    worktrees: list[WorktreeInfo] | None = None,
+    *,
+    base: str = _DEFAULT_WORKTREE_BASE,
+    repo: str | None = None,
+) -> list[dict]:
+    """Fetch PR status for worktrees and cache results.
+
+    Uses `gh pr list --head <branch>` per worktree, threaded for speed.
+    Returns list of result dicts.
+    """
+    if worktrees is None:
+        worktrees = scan_worktrees(base=base, repo=repo)
+
+    cache = _load_pr_cache()
+
+    def _fetch_pr(wt: WorktreeInfo) -> dict:
+        if not wt.branch or wt.branch in ("main", "master"):
+            return {"path": wt.path, "branch": wt.branch, "pr": None}
+
+        # Need to run gh in the worktree dir for correct repo context
+        result = _run_git(
+            ["gh", "pr", "list", "--head", wt.branch, "--state", "all",
+             "--json", "number,state,reviewDecision,mergeStateStatus", "--limit", "1"],
+            cwd=wt.path, timeout=15,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return {"path": wt.path, "branch": wt.branch, "pr": None}
+
+        prs = _json.loads(result.stdout)
+        if not prs:
+            return {"path": wt.path, "branch": wt.branch, "pr": None}
+
+        pr = prs[0]
+        return {
+            "path": wt.path,
+            "branch": wt.branch,
+            "pr": {
+                "number": pr["number"],
+                "state": pr["state"],
+                "review": pr.get("reviewDecision") or "PENDING",
+                "merge_state": pr.get("mergeStateStatus") or "UNKNOWN",
+            }
+        }
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_fetch_pr, worktrees))
+
+    # Update cache
+    for r in results:
+        cache[r["path"]] = {"branch": r["branch"], "pr": r.get("pr")}
+    _save_pr_cache(cache)
+
+    return results
 
 
 def clean_worktrees(worktrees: list[WorktreeInfo], *, dry_run: bool = True) -> list[dict]:

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from .core import (
     SessionInfo,
+    _worktree_parent_repo,
     is_branch_merged,
     list_sessions,
     remove_worktree,
@@ -480,9 +481,11 @@ def clean_worktrees(worktrees: list[WorktreeInfo], *, dry_run: bool = True) -> l
         }
 
         if not dry_run:
+            # Resolve parent repo before removal (path won't exist after)
+            repo_dir = _worktree_parent_repo(wt.path) or wt.path
             action["removed"] = remove_worktree(wt.path)
-            if wt.branch and wt.branch not in ("main", "master"):
-                action["branch_deleted"] = delete_branch(wt.path, wt.branch)
+            if wt.branch and wt.branch not in ("main", "master") and action["removed"]:
+                action["branch_deleted"] = delete_branch(repo_dir, wt.branch)
 
         actions.append(action)
 

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -77,16 +77,20 @@ class WorktreeInfo:
 
 
 def _detect_agent_type(wt_path: str, branch: str = "") -> str:
-    """Detect agent type from directory contents and branch name."""
-    has_codex = os.path.isdir(os.path.join(wt_path, ".codex"))
-    has_claude = os.path.isdir(os.path.join(wt_path, ".claude"))
-    # Branch prefix is a strong signal
+    """Detect agent type from branch name and directory markers.
+
+    Branch prefix is the strongest signal. Directory markers like .claude/
+    are often checked into repos and inherited by all worktrees, so they
+    are only used as a tiebreaker when .codex/ is absent.
+    """
+    # Branch prefix is authoritative
     if branch.startswith("codex/"):
         return "codex"
-    if has_codex and not has_claude:
-        return "codex"
-    if has_claude:
+    if branch.startswith("claude/"):
         return "claude"
+    # .codex/ without a claude branch prefix → codex
+    # (.claude/ is too common to be useful — most repos check it in)
+    has_codex = os.path.isdir(os.path.join(wt_path, ".codex"))
     if has_codex:
         return "codex"
     return "unknown"
@@ -360,16 +364,17 @@ def resume_worktree(
             jump_to_session(s.name)
             return {"action": "jumped", "session": s.name, "worktree": wt_path}
 
-    # Detect profile
+    # Detect profile from branch name
     profile_name = profile_override
     if not profile_name:
-        agent_type = _detect_agent_type(wt_path)
-        if agent_type == "claude":
-            profile_name = "claude"
-        elif agent_type == "codex":
+        # Get branch for detection
+        r = _run_git(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=wt_path, timeout=5)
+        branch = r.stdout.strip() if r.returncode == 0 else ""
+        agent_type = _detect_agent_type(wt_path, branch)
+        if agent_type == "codex":
             profile_name = "codex"
         else:
-            profile_name = "claude"  # default fallback
+            profile_name = "claude"  # default for claude and unknown
 
     # Build agent override command if --continue
     agent_override = None

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -76,11 +76,18 @@ class WorktreeInfo:
         }
 
 
-def _detect_agent_type(wt_path: str) -> str:
-    """Detect agent type from directory contents."""
-    if os.path.isdir(os.path.join(wt_path, ".claude")):
+def _detect_agent_type(wt_path: str, branch: str = "") -> str:
+    """Detect agent type from directory contents and branch name."""
+    has_codex = os.path.isdir(os.path.join(wt_path, ".codex"))
+    has_claude = os.path.isdir(os.path.join(wt_path, ".claude"))
+    # Branch prefix is a strong signal
+    if branch.startswith("codex/"):
+        return "codex"
+    if has_codex and not has_claude:
+        return "codex"
+    if has_claude:
         return "claude"
-    if os.path.isfile(os.path.join(wt_path, ".codex")):
+    if has_codex:
         return "codex"
     return "unknown"
 
@@ -106,23 +113,41 @@ def _probe_worktree(wt_path: str, *, full: bool = False) -> dict:
     """Gather git info for a single worktree directory."""
     result: dict = {"path": wt_path}
 
-    # Branch
-    r = _run_git(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=wt_path, timeout=5)
-    result["branch"] = r.stdout.strip() if r.returncode == 0 else ""
-
-    # Last commit date
-    r = _run_git(["git", "log", "-1", "--format=%aI"], cwd=wt_path, timeout=5)
+    # Single git call for branch + last commit date
+    r = _run_git(
+        ["git", "log", "-1", "--format=%D%n%aI"],
+        cwd=wt_path, timeout=5,
+    )
     if r.returncode == 0 and r.stdout.strip():
-        try:
-            result["last_commit_date"] = datetime.fromisoformat(r.stdout.strip())
-        except ValueError:
+        lines = r.stdout.strip().splitlines()
+        # First line: refs (e.g. "HEAD -> feat/foo, origin/feat/foo")
+        refs_line = lines[0] if lines else ""
+        branch = ""
+        for ref in refs_line.split(","):
+            ref = ref.strip()
+            if ref.startswith("HEAD -> "):
+                branch = ref[len("HEAD -> "):]
+                break
+        result["branch"] = branch
+        # Second line: author date ISO
+        date_str = lines[1].strip() if len(lines) > 1 else ""
+        if date_str:
+            try:
+                result["last_commit_date"] = datetime.fromisoformat(date_str)
+            except ValueError:
+                result["last_commit_date"] = None
+        else:
             result["last_commit_date"] = None
     else:
+        result["branch"] = ""
         result["last_commit_date"] = None
 
-    # Uncommitted changes
-    r = _run_git(["git", "status", "--porcelain"], cwd=wt_path, timeout=5)
-    result["has_uncommitted"] = r.returncode == 0 and bool(r.stdout.strip())
+    # Uncommitted changes — only in full mode (expensive for 554 worktrees)
+    if full:
+        r = _run_git(["git", "status", "--porcelain"], cwd=wt_path, timeout=5)
+        result["has_uncommitted"] = r.returncode == 0 and bool(r.stdout.strip())
+    else:
+        result["has_uncommitted"] = False
 
     # Full mode: merged and unpushed checks
     if full:
@@ -168,7 +193,7 @@ def scan_worktrees(
         return []
 
     # Phase 1: Scan directories
-    candidates: list[tuple[str, str, str]] = []  # (path, repo_name, agent_type)
+    candidates: list[tuple[str, str]] = []  # (path, repo_name)
     with os.scandir(base_expanded) as entries:
         for entry in entries:
             if not entry.is_dir(follow_symlinks=False):
@@ -181,18 +206,18 @@ def scan_worktrees(
             repo_name = _read_repo_name(wt_path)
             if repo and repo_name != repo:
                 continue
-            agent_type = _detect_agent_type(wt_path)
-            candidates.append((wt_path, repo_name, agent_type))
+            candidates.append((wt_path, repo_name))
 
     if not candidates:
         return []
 
     # Phase 2: Parallel git queries
-    def _probe(item: tuple[str, str, str]) -> dict:
-        wt_path, repo_name, agent_type = item
+    def _probe(item: tuple[str, str]) -> dict:
+        wt_path, repo_name = item
         info = _probe_worktree(wt_path, full=full)
         info["repo_name"] = repo_name
-        info["agent_type"] = agent_type
+        # Detect agent using both directory and branch info
+        info["agent_type"] = _detect_agent_type(wt_path, info.get("branch", ""))
         return info
 
     with ThreadPoolExecutor(max_workers=16) as pool:

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -324,22 +324,63 @@ def get_cached_pr(wt_path: str) -> dict | None:
 
 
 def find_worktree(name: str, base: str = _DEFAULT_WORKTREE_BASE) -> str | None:
-    """Find a worktree by name (exact basename match or substring)."""
-    base_expanded = os.path.expanduser(base)
-    if not os.path.isdir(base_expanded):
-        return None
-    exact = os.path.join(base_expanded, name)
-    if os.path.isdir(exact):
-        return exact
-    # Substring match
-    matches = []
-    with os.scandir(base_expanded) as entries:
-        for entry in entries:
-            if entry.is_dir() and name in entry.name:
-                matches.append(entry.path)
+    """Find a single worktree by name (exact basename match or unique substring)."""
+    matches = find_worktrees([name], base=base)
     if len(matches) == 1:
         return matches[0]
     return None
+
+
+def find_worktrees(
+    patterns: list[str],
+    base: str = _DEFAULT_WORKTREE_BASE,
+) -> list[str]:
+    """Find worktrees matching any of the given patterns.
+
+    Each pattern is tried as:
+    1. Exact directory name
+    2. Regex match against directory name
+    3. Substring match (fallback)
+
+    Returns deduplicated list of matching paths.
+    """
+    import re as _re
+
+    base_expanded = os.path.expanduser(base)
+    if not os.path.isdir(base_expanded):
+        return []
+
+    # Gather all worktree dir names
+    all_dirs: list[tuple[str, str]] = []  # (name, full_path)
+    with os.scandir(base_expanded) as entries:
+        for entry in entries:
+            if entry.is_dir(follow_symlinks=False):
+                all_dirs.append((entry.name, entry.path))
+
+    matched: dict[str, str] = {}  # path -> path (dedup)
+    for pattern in patterns:
+        # Try exact match first
+        exact = os.path.join(base_expanded, pattern)
+        if os.path.isdir(exact):
+            matched[exact] = exact
+            continue
+
+        # Try as regex
+        try:
+            regex = _re.compile(pattern)
+            for dirname, dirpath in all_dirs:
+                if regex.search(dirname):
+                    matched[dirpath] = dirpath
+            continue
+        except _re.error:
+            pass
+
+        # Fallback: substring
+        for dirname, dirpath in all_dirs:
+            if pattern in dirname:
+                matched[dirpath] = dirpath
+
+    return sorted(matched.values())
 
 
 def resume_worktree(
@@ -348,45 +389,80 @@ def resume_worktree(
     base: str = _DEFAULT_WORKTREE_BASE,
     profile_override: str | None = None,
     continue_session: bool = False,
+    jump: bool = True,
 ) -> dict:
-    """Resume work in a worktree - jump to existing session or create new one.
+    """Resume work in a single worktree - jump to existing session or create new one.
 
-    Returns dict with action taken: {"action": "jumped"|"created", "session": name, ...}
+    Returns dict with action taken: {"action": "jumped"|"created"|"exists", ...}
     """
     wt_path = find_worktree(name, base=base)
     if not wt_path:
         raise RuntimeError(f"No worktree matching '{name}' found in {base}")
 
+    return _resume_one(wt_path, profile_override=profile_override,
+                       continue_session=continue_session, jump=jump)
+
+
+def resume_worktrees(
+    patterns: list[str],
+    *,
+    base: str = _DEFAULT_WORKTREE_BASE,
+    profile_override: str | None = None,
+    continue_session: bool = False,
+) -> list[dict]:
+    """Resume work in multiple worktrees matching patterns.
+
+    Creates sessions for all matching worktrees (does not jump).
+    Returns list of action dicts.
+    """
+    paths = find_worktrees(patterns, base=base)
+    if not paths:
+        raise RuntimeError(f"No worktrees matching patterns: {patterns}")
+
+    results = []
+    for wt_path in paths:
+        result = _resume_one(wt_path, profile_override=profile_override,
+                             continue_session=continue_session, jump=False)
+        results.append(result)
+    return results
+
+
+def _resume_one(
+    wt_path: str,
+    *,
+    profile_override: str | None = None,
+    continue_session: bool = False,
+    jump: bool = True,
+) -> dict:
+    """Resume a single worktree path."""
+    from .core import session_exists, uniqueify_session_name, create_profile_session, jump_to_session
+
     # Check if there's already a session using this worktree
     sessions = list_sessions()
     for s in sessions:
         if s.working_dir == wt_path:
-            from .core import jump_to_session
-            jump_to_session(s.name)
-            return {"action": "jumped", "session": s.name, "worktree": wt_path}
+            if jump:
+                jump_to_session(s.name)
+            return {"action": "exists", "session": s.name, "worktree": wt_path}
 
     # Detect profile from branch name
     profile_name = profile_override
     if not profile_name:
-        # Get branch for detection
         r = _run_git(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=wt_path, timeout=5)
         branch = r.stdout.strip() if r.returncode == 0 else ""
         agent_type = _detect_agent_type(wt_path, branch)
         if agent_type == "codex":
             profile_name = "codex"
         else:
-            profile_name = "claude"  # default for claude and unknown
+            profile_name = "claude"
 
     # Build agent override command if --continue
     agent_override = None
     if continue_session and profile_name == "claude":
         agent_override = "claude --continue --permission-mode bypassPermissions"
-    elif continue_session and profile_name == "codex":
-        agent_override = None  # codex doesn't have --continue
 
     # Session name = worktree basename
     session_name = os.path.basename(wt_path)
-    from .core import session_exists, uniqueify_session_name, create_profile_session, jump_to_session
     if session_exists(session_name):
         session_name = uniqueify_session_name(session_name)
 
@@ -397,7 +473,8 @@ def resume_worktree(
         directory=wt_path,
     )
 
-    jump_to_session(session_name)
+    if jump:
+        jump_to_session(session_name)
     return {"action": "created", "session": session_name, "worktree": wt_path, "profile": profile_name}
 
 

--- a/src/tmux_pilot/worktree.py
+++ b/src/tmux_pilot/worktree.py
@@ -457,9 +457,13 @@ def _resume_one(
             profile_name = "claude"
 
     # Build agent override command if --continue
+    # Appends --continue to the profile's configured command rather than hardcoding
     agent_override = None
-    if continue_session and profile_name == "claude":
-        agent_override = "claude --continue --permission-mode bypassPermissions"
+    if continue_session and profile_name in ("claude", "codex"):
+        from .core import resolve_session_profile
+        profile = resolve_session_profile(profile_name)
+        if profile and profile.command_parts:
+            agent_override = " ".join(profile.command_parts) + " --continue"
 
     # Session name = worktree basename
     session_name = os.path.basename(wt_path)

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -139,23 +139,25 @@ class TestReadRepoName:
 
 
 class TestDetectAgentType:
-    def test_detects_claude(self, tmp_path):
-        (tmp_path / ".claude").mkdir()
-        assert _detect_agent_type(str(tmp_path)) == "claude"
+    def test_codex_branch_prefix(self, tmp_path):
+        assert _detect_agent_type(str(tmp_path), branch="codex/fix-thing") == "codex"
 
-    def test_detects_codex(self, tmp_path):
+    def test_claude_branch_prefix(self, tmp_path):
+        assert _detect_agent_type(str(tmp_path), branch="claude/add-feature") == "claude"
+
+    def test_codex_dir_without_branch(self, tmp_path):
         (tmp_path / ".codex").mkdir()
         assert _detect_agent_type(str(tmp_path)) == "codex"
 
-    def test_returns_unknown(self, tmp_path):
+    def test_claude_dir_alone_is_not_enough(self, tmp_path):
+        # .claude/ is often checked into repos, so it's not a reliable signal
+        (tmp_path / ".claude").mkdir()
         assert _detect_agent_type(str(tmp_path)) == "unknown"
 
-    def test_claude_takes_priority_over_codex(self, tmp_path):
-        (tmp_path / ".claude").mkdir()
-        (tmp_path / ".codex").mkdir()
-        assert _detect_agent_type(str(tmp_path)) == "claude"
+    def test_returns_unknown_when_no_signal(self, tmp_path):
+        assert _detect_agent_type(str(tmp_path)) == "unknown"
 
-    def test_codex_branch_prefix_overrides_claude_dir(self, tmp_path):
+    def test_codex_branch_overrides_claude_dir(self, tmp_path):
         (tmp_path / ".claude").mkdir()
         assert _detect_agent_type(str(tmp_path), branch="codex/fix-thing") == "codex"
 
@@ -180,11 +182,11 @@ class TestScanWorktrees:
         assert result == []
 
     def test_scans_worktrees(self, tmp_path, monkeypatch):
-        # Create a fake worktree
+        # Create a fake worktree with .codex dir (reliable signal)
         wt_dir = tmp_path / "feature-x"
         wt_dir.mkdir()
         (wt_dir / ".git").write_text("gitdir: /repos/myrepo/.git/worktrees/feature-x\n")
-        (wt_dir / ".claude").mkdir()
+        (wt_dir / ".codex").mkdir()
 
         # Mock _probe_worktree to avoid real git commands
         import subprocess as _sp
@@ -205,7 +207,7 @@ class TestScanWorktrees:
         assert len(result) == 1
         assert result[0].repo_name == "myrepo"
         assert result[0].branch == "feature-x"
-        assert result[0].agent_type == "claude"
+        assert result[0].agent_type == "codex"
         assert result[0].is_orphan is True
 
     def test_repo_filter(self, tmp_path, monkeypatch):

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -144,7 +144,7 @@ class TestDetectAgentType:
         assert _detect_agent_type(str(tmp_path)) == "claude"
 
     def test_detects_codex(self, tmp_path):
-        (tmp_path / ".codex").write_text("")
+        (tmp_path / ".codex").mkdir()
         assert _detect_agent_type(str(tmp_path)) == "codex"
 
     def test_returns_unknown(self, tmp_path):
@@ -152,8 +152,12 @@ class TestDetectAgentType:
 
     def test_claude_takes_priority_over_codex(self, tmp_path):
         (tmp_path / ".claude").mkdir()
-        (tmp_path / ".codex").write_text("")
+        (tmp_path / ".codex").mkdir()
         assert _detect_agent_type(str(tmp_path)) == "claude"
+
+    def test_codex_branch_prefix_overrides_claude_dir(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        assert _detect_agent_type(str(tmp_path), branch="codex/fix-thing") == "codex"
 
 
 # ---------------------------------------------------------------------------
@@ -185,12 +189,11 @@ class TestScanWorktrees:
         # Mock _probe_worktree to avoid real git commands
         import subprocess as _sp
 
+        dt = datetime.now(timezone.utc).isoformat()
+
         def fake_run_git(args, *, cwd=None, timeout=10):
-            if "rev-parse" in args:
-                return _sp.CompletedProcess(args, 0, stdout="feature-x\n", stderr="")
-            if "log" in args and "--format=%aI" in args:
-                dt = datetime.now(timezone.utc).isoformat()
-                return _sp.CompletedProcess(args, 0, stdout=dt + "\n", stderr="")
+            if "log" in args and "--format=%D%n%aI" in args:
+                return _sp.CompletedProcess(args, 0, stdout=f"HEAD -> feature-x\n{dt}\n", stderr="")
             if "status" in args:
                 return _sp.CompletedProcess(args, 0, stdout="", stderr="")
             return _sp.CompletedProcess(args, 1, stdout="", stderr="")
@@ -214,12 +217,11 @@ class TestScanWorktrees:
 
         import subprocess as _sp
 
+        dt = datetime.now(timezone.utc).isoformat()
+
         def fake_run_git(args, *, cwd=None, timeout=10):
-            if "rev-parse" in args:
-                return _sp.CompletedProcess(args, 0, stdout="main\n", stderr="")
-            if "log" in args:
-                dt = datetime.now(timezone.utc).isoformat()
-                return _sp.CompletedProcess(args, 0, stdout=dt + "\n", stderr="")
+            if "log" in args and "--format=%D%n%aI" in args:
+                return _sp.CompletedProcess(args, 0, stdout=f"HEAD -> main\n{dt}\n", stderr="")
             if "status" in args:
                 return _sp.CompletedProcess(args, 0, stdout="", stderr="")
             return _sp.CompletedProcess(args, 1, stdout="", stderr="")
@@ -239,12 +241,11 @@ class TestScanWorktrees:
         import subprocess as _sp
         from tmux_pilot.core import SessionInfo
 
+        dt = datetime.now(timezone.utc).isoformat()
+
         def fake_run_git(args, *, cwd=None, timeout=10):
-            if "rev-parse" in args:
-                return _sp.CompletedProcess(args, 0, stdout="feat\n", stderr="")
-            if "log" in args:
-                dt = datetime.now(timezone.utc).isoformat()
-                return _sp.CompletedProcess(args, 0, stdout=dt + "\n", stderr="")
+            if "log" in args and "--format=%D%n%aI" in args:
+                return _sp.CompletedProcess(args, 0, stdout=f"HEAD -> feat\n{dt}\n", stderr="")
             if "status" in args:
                 return _sp.CompletedProcess(args, 0, stdout="", stderr="")
             return _sp.CompletedProcess(args, 1, stdout="", stderr="")
@@ -275,10 +276,8 @@ class TestScanWorktrees:
         old_date = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
 
         def fake_run_git(args, *, cwd=None, timeout=10):
-            if "rev-parse" in args:
-                return _sp.CompletedProcess(args, 0, stdout="old-branch\n", stderr="")
-            if "log" in args:
-                return _sp.CompletedProcess(args, 0, stdout=old_date + "\n", stderr="")
+            if "log" in args and "--format=%D%n%aI" in args:
+                return _sp.CompletedProcess(args, 0, stdout=f"HEAD -> old-branch\n{old_date}\n", stderr="")
             if "status" in args:
                 return _sp.CompletedProcess(args, 0, stdout="", stderr="")
             return _sp.CompletedProcess(args, 1, stdout="", stderr="")

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,0 +1,451 @@
+"""Tests for tmux_pilot.worktree module."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from tmux_pilot.worktree import (
+    WorktreeInfo,
+    scan_worktrees,
+    worktree_summary,
+    clean_worktrees,
+    _read_repo_name,
+    _detect_agent_type,
+)
+from tmux_pilot.cli import main as cli_main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_wt(
+    path="/tmp/wt/branch-a",
+    repo_name="myrepo",
+    branch="branch-a",
+    age_days=1.0,
+    has_session=True,
+    session_name="sess-a",
+    agent_type="claude",
+    is_merged=False,
+    has_unpushed=False,
+    has_uncommitted=False,
+    last_commit_date=None,
+) -> WorktreeInfo:
+    if last_commit_date is None:
+        last_commit_date = datetime.now(timezone.utc) - timedelta(days=age_days)
+    return WorktreeInfo(
+        path=path,
+        repo_name=repo_name,
+        branch=branch,
+        last_commit_date=last_commit_date,
+        age_days=age_days,
+        has_session=has_session,
+        session_name=session_name,
+        agent_type=agent_type,
+        is_merged=is_merged,
+        has_unpushed=has_unpushed,
+        has_uncommitted=has_uncommitted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# WorktreeInfo properties
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeInfoProperties:
+    def test_is_orphan_true_when_no_session(self):
+        wt = _make_wt(has_session=False)
+        assert wt.is_orphan is True
+
+    def test_is_orphan_false_when_has_session(self):
+        wt = _make_wt(has_session=True)
+        assert wt.is_orphan is False
+
+    def test_is_stale_true_when_old(self):
+        wt = _make_wt(age_days=10.0)
+        assert wt.is_stale is True
+
+    def test_is_stale_false_when_recent(self):
+        wt = _make_wt(age_days=3.0)
+        assert wt.is_stale is False
+
+    def test_is_stale_boundary(self):
+        wt = _make_wt(age_days=7.0)
+        assert wt.is_stale is False  # >7 required, not >=7
+
+    def test_to_dict_keys(self):
+        wt = _make_wt()
+        d = wt.to_dict()
+        expected_keys = {
+            "path", "repo_name", "branch", "last_commit_date",
+            "age_days", "has_session", "session_name", "agent_type",
+            "is_merged", "has_unpushed", "has_uncommitted",
+            "is_orphan", "is_stale",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_to_dict_values(self):
+        wt = _make_wt(path="/tmp/x", repo_name="r", branch="b", age_days=2.5)
+        d = wt.to_dict()
+        assert d["path"] == "/tmp/x"
+        assert d["repo_name"] == "r"
+        assert d["branch"] == "b"
+        assert d["age_days"] == 2.5
+        assert d["is_orphan"] is False
+        assert d["is_stale"] is False
+
+
+# ---------------------------------------------------------------------------
+# _read_repo_name
+# ---------------------------------------------------------------------------
+
+
+class TestReadRepoName:
+    def test_reads_repo_from_gitdir(self, tmp_path):
+        wt_dir = tmp_path / "feature-branch"
+        wt_dir.mkdir()
+        git_file = wt_dir / ".git"
+        git_file.write_text("gitdir: /home/user/repos/myrepo/.git/worktrees/feature-branch\n")
+        assert _read_repo_name(str(wt_dir)) == "myrepo"
+
+    def test_nested_path(self, tmp_path):
+        wt_dir = tmp_path / "fix-123"
+        wt_dir.mkdir()
+        git_file = wt_dir / ".git"
+        git_file.write_text("gitdir: /a/b/c/coolproject/.git/worktrees/fix-123\n")
+        assert _read_repo_name(str(wt_dir)) == "coolproject"
+
+    def test_falls_back_to_dirname_when_no_git_file(self, tmp_path):
+        wt_dir = tmp_path / "my-worktree"
+        wt_dir.mkdir()
+        assert _read_repo_name(str(wt_dir)) == "my-worktree"
+
+    def test_falls_back_when_git_is_directory(self, tmp_path):
+        wt_dir = tmp_path / "some-wt"
+        wt_dir.mkdir()
+        (wt_dir / ".git").mkdir()
+        assert _read_repo_name(str(wt_dir)) == "some-wt"
+
+
+# ---------------------------------------------------------------------------
+# _detect_agent_type
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAgentType:
+    def test_detects_claude(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        assert _detect_agent_type(str(tmp_path)) == "claude"
+
+    def test_detects_codex(self, tmp_path):
+        (tmp_path / ".codex").write_text("")
+        assert _detect_agent_type(str(tmp_path)) == "codex"
+
+    def test_returns_unknown(self, tmp_path):
+        assert _detect_agent_type(str(tmp_path)) == "unknown"
+
+    def test_claude_takes_priority_over_codex(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".codex").write_text("")
+        assert _detect_agent_type(str(tmp_path)) == "claude"
+
+
+# ---------------------------------------------------------------------------
+# scan_worktrees
+# ---------------------------------------------------------------------------
+
+
+class TestScanWorktrees:
+    def test_returns_empty_for_nonexistent_base(self):
+        result = scan_worktrees("/nonexistent/path/xyz123")
+        assert result == []
+
+    def test_returns_empty_for_empty_dir(self, tmp_path):
+        result = scan_worktrees(str(tmp_path))
+        assert result == []
+
+    def test_skips_dirs_without_git_file(self, tmp_path):
+        (tmp_path / "some-dir").mkdir()
+        result = scan_worktrees(str(tmp_path))
+        assert result == []
+
+    def test_scans_worktrees(self, tmp_path, monkeypatch):
+        # Create a fake worktree
+        wt_dir = tmp_path / "feature-x"
+        wt_dir.mkdir()
+        (wt_dir / ".git").write_text("gitdir: /repos/myrepo/.git/worktrees/feature-x\n")
+        (wt_dir / ".claude").mkdir()
+
+        # Mock _probe_worktree to avoid real git commands
+        import subprocess as _sp
+
+        def fake_run_git(args, *, cwd=None, timeout=10):
+            if "rev-parse" in args:
+                return _sp.CompletedProcess(args, 0, stdout="feature-x\n", stderr="")
+            if "log" in args and "--format=%aI" in args:
+                dt = datetime.now(timezone.utc).isoformat()
+                return _sp.CompletedProcess(args, 0, stdout=dt + "\n", stderr="")
+            if "status" in args:
+                return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+            return _sp.CompletedProcess(args, 1, stdout="", stderr="")
+
+        monkeypatch.setattr("tmux_pilot.worktree._run_git", fake_run_git)
+        monkeypatch.setattr("tmux_pilot.worktree.list_sessions", lambda: [])
+
+        result = scan_worktrees(str(tmp_path))
+        assert len(result) == 1
+        assert result[0].repo_name == "myrepo"
+        assert result[0].branch == "feature-x"
+        assert result[0].agent_type == "claude"
+        assert result[0].is_orphan is True
+
+    def test_repo_filter(self, tmp_path, monkeypatch):
+        # Two worktrees, different repos
+        for name, repo in [("wt-a", "repoA"), ("wt-b", "repoB")]:
+            d = tmp_path / name
+            d.mkdir()
+            (d / ".git").write_text(f"gitdir: /repos/{repo}/.git/worktrees/{name}\n")
+
+        import subprocess as _sp
+
+        def fake_run_git(args, *, cwd=None, timeout=10):
+            if "rev-parse" in args:
+                return _sp.CompletedProcess(args, 0, stdout="main\n", stderr="")
+            if "log" in args:
+                dt = datetime.now(timezone.utc).isoformat()
+                return _sp.CompletedProcess(args, 0, stdout=dt + "\n", stderr="")
+            if "status" in args:
+                return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+            return _sp.CompletedProcess(args, 1, stdout="", stderr="")
+
+        monkeypatch.setattr("tmux_pilot.worktree._run_git", fake_run_git)
+        monkeypatch.setattr("tmux_pilot.worktree.list_sessions", lambda: [])
+
+        result = scan_worktrees(str(tmp_path), repo="repoA")
+        assert len(result) == 1
+        assert result[0].repo_name == "repoA"
+
+    def test_orphan_only_filter(self, tmp_path, monkeypatch):
+        wt_dir = tmp_path / "feat"
+        wt_dir.mkdir()
+        (wt_dir / ".git").write_text("gitdir: /repos/r/.git/worktrees/feat\n")
+
+        import subprocess as _sp
+        from tmux_pilot.core import SessionInfo
+
+        def fake_run_git(args, *, cwd=None, timeout=10):
+            if "rev-parse" in args:
+                return _sp.CompletedProcess(args, 0, stdout="feat\n", stderr="")
+            if "log" in args:
+                dt = datetime.now(timezone.utc).isoformat()
+                return _sp.CompletedProcess(args, 0, stdout=dt + "\n", stderr="")
+            if "status" in args:
+                return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+            return _sp.CompletedProcess(args, 1, stdout="", stderr="")
+
+        # Session matches the worktree path
+        fake_session = SessionInfo(
+            name="feat",
+            working_dir=str(wt_dir), process="zsh", pid="1234",
+        )
+        monkeypatch.setattr("tmux_pilot.worktree._run_git", fake_run_git)
+        monkeypatch.setattr("tmux_pilot.worktree.list_sessions", lambda: [fake_session])
+
+        # With orphan_only, the session-linked worktree should be excluded
+        result = scan_worktrees(str(tmp_path), orphan_only=True)
+        assert len(result) == 0
+
+        # Without filter it should appear
+        result = scan_worktrees(str(tmp_path))
+        assert len(result) == 1
+
+    def test_stale_days_filter(self, tmp_path, monkeypatch):
+        wt_dir = tmp_path / "old-branch"
+        wt_dir.mkdir()
+        (wt_dir / ".git").write_text("gitdir: /repos/r/.git/worktrees/old-branch\n")
+
+        import subprocess as _sp
+
+        old_date = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+
+        def fake_run_git(args, *, cwd=None, timeout=10):
+            if "rev-parse" in args:
+                return _sp.CompletedProcess(args, 0, stdout="old-branch\n", stderr="")
+            if "log" in args:
+                return _sp.CompletedProcess(args, 0, stdout=old_date + "\n", stderr="")
+            if "status" in args:
+                return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+            return _sp.CompletedProcess(args, 1, stdout="", stderr="")
+
+        monkeypatch.setattr("tmux_pilot.worktree._run_git", fake_run_git)
+        monkeypatch.setattr("tmux_pilot.worktree.list_sessions", lambda: [])
+
+        # stale_days=30 means only show worktrees older than 30 days
+        result = scan_worktrees(str(tmp_path), stale_days=30)
+        assert len(result) == 0
+
+        # stale_days=10 means show worktrees older than 10 days (20 > 10)
+        result = scan_worktrees(str(tmp_path), stale_days=10)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# worktree_summary
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeSummary:
+    def test_empty_list(self):
+        s = worktree_summary([])
+        assert s == {"total": 0, "by_repo": {}, "by_status": {"orphan": 0, "stale": 0, "active": 0, "merged": 0}}
+
+    def test_counts_by_repo(self):
+        wts = [
+            _make_wt(repo_name="alpha"),
+            _make_wt(repo_name="alpha"),
+            _make_wt(repo_name="beta"),
+        ]
+        s = worktree_summary(wts)
+        assert s["total"] == 3
+        assert s["by_repo"] == {"alpha": 2, "beta": 1}
+
+    def test_status_categories(self):
+        wts = [
+            _make_wt(has_session=True, age_days=1, is_merged=False),   # active
+            _make_wt(has_session=False, age_days=1, is_merged=False),  # orphan
+            _make_wt(has_session=True, age_days=10, is_merged=False),  # stale
+            _make_wt(has_session=True, age_days=1, is_merged=True),    # merged
+        ]
+        s = worktree_summary(wts)
+        assert s["by_status"]["active"] == 1
+        assert s["by_status"]["orphan"] == 1
+        assert s["by_status"]["stale"] == 1
+        assert s["by_status"]["merged"] == 1
+
+    def test_merged_takes_priority(self):
+        # A merged worktree that is also orphan should be counted as merged
+        wt = _make_wt(has_session=False, is_merged=True, age_days=20)
+        s = worktree_summary([wt])
+        assert s["by_status"]["merged"] == 1
+        assert s["by_status"]["orphan"] == 0
+
+
+# ---------------------------------------------------------------------------
+# clean_worktrees
+# ---------------------------------------------------------------------------
+
+
+class TestCleanWorktrees:
+    def test_dry_run_returns_actions_without_removal(self):
+        wts = [
+            _make_wt(path="/tmp/wt/merged-one", branch="feat-1", is_merged=True),
+            _make_wt(path="/tmp/wt/orphan-stale", branch="feat-2", has_session=False, age_days=10),
+        ]
+        actions = clean_worktrees(wts, dry_run=True)
+        assert len(actions) == 2
+        assert actions[0]["reason"] == "merged"
+        assert actions[0]["dry_run"] is True
+        assert actions[0]["removed"] is False
+        assert actions[1]["reason"] == "orphan+stale"
+
+    def test_skips_active_worktrees(self):
+        wts = [
+            _make_wt(has_session=True, age_days=1, is_merged=False),
+        ]
+        actions = clean_worktrees(wts, dry_run=True)
+        assert actions == []
+
+    def test_skips_orphan_but_not_stale(self):
+        wts = [
+            _make_wt(has_session=False, age_days=3, is_merged=False),
+        ]
+        actions = clean_worktrees(wts, dry_run=True)
+        assert actions == []
+
+    def test_includes_orphan_and_stale(self):
+        wts = [
+            _make_wt(has_session=False, age_days=10, is_merged=False),
+        ]
+        actions = clean_worktrees(wts, dry_run=True)
+        assert len(actions) == 1
+        assert actions[0]["reason"] == "orphan+stale"
+
+    def test_actual_removal_calls_core(self, monkeypatch):
+        removed_paths = []
+        deleted_branches = []
+
+        monkeypatch.setattr("tmux_pilot.worktree.remove_worktree", lambda p: (removed_paths.append(p), True)[1])
+        monkeypatch.setattr("tmux_pilot.worktree.delete_branch", lambda p, b: (deleted_branches.append((p, b)), True)[1])
+
+        wts = [_make_wt(path="/tmp/wt/x", branch="feat-x", is_merged=True)]
+        actions = clean_worktrees(wts, dry_run=False)
+        assert actions[0]["removed"] is True
+        assert actions[0]["branch_deleted"] is True
+        assert removed_paths == ["/tmp/wt/x"]
+        assert deleted_branches == [("/tmp/wt/x", "feat-x")]
+
+    def test_does_not_delete_main_branch(self, monkeypatch):
+        deleted_branches = []
+        monkeypatch.setattr("tmux_pilot.worktree.remove_worktree", lambda p: True)
+        monkeypatch.setattr("tmux_pilot.worktree.delete_branch", lambda p, b: (deleted_branches.append(b), True)[1])
+
+        wts = [_make_wt(path="/tmp/wt/y", branch="main", is_merged=True)]
+        actions = clean_worktrees(wts, dry_run=False)
+        assert actions[0]["removed"] is True
+        assert actions[0]["branch_deleted"] is False
+        assert deleted_branches == []
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIWorktree:
+    def test_wt_ls_json(self, monkeypatch, capsys):
+        fake_wt = _make_wt(path="/tmp/wt/test", branch="test-br")
+        monkeypatch.setattr("tmux_pilot.worktree.scan_worktrees", lambda **kw: [fake_wt])
+
+        try:
+            cli_main(["wt", "ls", "--json"])
+        except SystemExit as e:
+            if e.code not in (None, 0):
+                pytest.fail(f"CLI exited with code {e.code}")
+
+        out = capsys.readouterr().out
+        assert "test-br" in out
+
+    def test_wt_ls_json_output(self, monkeypatch, capsys):
+        fake_wt = _make_wt(path="/tmp/wt/test", branch="test-br")
+        monkeypatch.setattr("tmux_pilot.worktree.scan_worktrees", lambda **kw: [fake_wt])
+
+        try:
+            cli_main(["wt", "ls", "--json"])
+        except SystemExit:
+            pass
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert data[0]["branch"] == "test-br"
+
+    def test_wt_status_json(self, monkeypatch, capsys):
+        wts = [_make_wt(repo_name="r1"), _make_wt(repo_name="r2", has_session=False)]
+        monkeypatch.setattr("tmux_pilot.worktree.scan_worktrees", lambda **kw: wts)
+
+        try:
+            cli_main(["wt", "status", "--json"])
+        except SystemExit:
+            pass
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["total"] == 2
+        assert "by_repo" in data
+        assert "by_status" in data


### PR DESCRIPTION
## Summary

Adds `tp wt` worktree management commands for listing, status inspection, cleanup, refresh, and resume workflows. The branch also adds worktree scanning helpers and public core wrappers, PR metadata caching for worktrees, documentation for the new commands, and fixes around resume behavior, worktree cleanup, `.claude/` detection, and scan performance.

## Why

Managing multiple task worktrees from `tmux-pilot` needs a first-class workflow rather than ad hoc shell commands. These commands make it easier to inspect active worktrees, refresh PR metadata, resume existing sessions, and clean up finished worktrees from the same CLI surface.

## Validation

- `pytest -q --ignore=tests/test_send_keys_tmux.py` passed after merging `origin/main`: 192 tests.
- `pytest -q` was attempted before the merge, but the real tmux integration tests failed in this local environment because tmux could not fork new panes: `create window failed: fork failed: Device not configured`. The failures were confined to `tests/test_send_keys_tmux.py`.