### PR TITLE
[codex] fix tp reap confirmation flow

### DIFF
--- a/src/tmux_pilot/cli.py
+++ b/src/tmux_pilot/cli.py
@@ -756,38 +756,55 @@ def cmd_install_hooks(args: argparse.Namespace) -> None:
         print(f"Hooks in {actions['hooks_dir']}, core.hooksPath configured.")
 
 
+def _reap_row(r: dict) -> str:
+    return f"  {r['session']}  branch={r.get('branch') or '-'}  pr=#{r.get('pr') or '-'}  [{r.get('reason', '')}]"
+
+
 def cmd_reap(args: argparse.Namespace) -> None:
     from . import reaper
-    results = reaper.reap_sessions(
-        dry_run=args.dry_run,
+
+    # Always preview first so we never kill before the user confirms.
+    preview = reaper.reap_sessions(
+        dry_run=True,
         force=args.force,
         include_no_pr=args.include_no_pr,
+        include_dead=args.include_dead,
     )
-    if not results:
-        print("No sessions to reap.")
-        return
+    to_reap = [r for r in preview if r.get("action") == "confirm"]
+    skipped = [r for r in preview if r.get("skipped")]
 
     if args.dry_run:
-        print("Dry run -- would reap:")
-        for r in results:
-            flag = r.get("reason", "")
-            print(f"  {r['session']}  branch={r.get('branch', '?')}  pr=#{r.get('pr', '-')}  [{flag}]")
+        if to_reap:
+            print("Would reap:")
+            for r in to_reap:
+                print(_reap_row(r))
+        else:
+            print("Nothing to reap.")
+        if skipped:
+            print("Would skip:")
+            for r in skipped:
+                print(_reap_row(r))
+        return
+
+    if not to_reap:
+        print("No sessions to reap.")
+        if skipped:
+            print(f"({len(skipped)} skipped: " + ", ".join(f"{r['session']} [{r.get('reason', '')}]" for r in skipped) + ")")
         return
 
     if not args.force:
-        names = ", ".join(r["session"] for r in results if r.get("action") == "confirm")
-        if names:
-            resp = input(f"Reap session(s): {names}? [y/N] ")
-            if resp.lower() not in ("y", "yes"):
-                print("Aborted.")
-                return
-            # Actually reap after confirmation
-            results = reaper.reap_sessions(
-                dry_run=False,
-                force=True,
-                include_no_pr=args.include_no_pr,
-            )
+        names = ", ".join(r["session"] for r in to_reap)
+        resp = input(f"Reap {len(to_reap)} session(s): {names}? [y/N] ")
+        if resp.lower() not in ("y", "yes"):
+            print("Aborted.")
+            return
 
+    results = reaper.reap_sessions(
+        dry_run=False,
+        force=args.force,
+        include_no_pr=args.include_no_pr,
+        include_dead=args.include_dead,
+    )
     for r in results:
         parts = [r["session"]]
         if r.get("killed"):
@@ -1089,6 +1106,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_reap.add_argument("--dry-run", action="store_true", help="Preview without executing")
     p_reap.add_argument("--force", action="store_true", help="Skip confirmation prompt")
     p_reap.add_argument("--include-no-pr", action="store_true", help="Also flag clean sessions with no PR")
+    p_reap.add_argument("--include-dead", action="store_true", help="Also reap bare sessions whose worktree is gone (kills the session only)")
 
     # refresh
     p_refresh = sub.add_parser("refresh", help="Refresh cached PR metadata")

--- a/src/tmux_pilot/reaper.py
+++ b/src/tmux_pilot/reaper.py
@@ -41,6 +41,52 @@ def _has_uncommitted(working_dir: str) -> bool:
     return result.returncode == 0 and bool(result.stdout.strip())
 
 
+def _is_inside_git_worktree(working_dir: str) -> bool:
+    """True if *working_dir* is inside any git work tree."""
+    if not working_dir:
+        return False
+    result = subprocess.run(
+        ["git", "-C", working_dir, "rev-parse", "--is-inside-work-tree"],
+        capture_output=True, text=True, timeout=5,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _is_dead_session(session: core.SessionInfo) -> bool:
+    """A bare, branchless session whose cwd is no longer inside a git work tree.
+
+    These are typically sessions whose worktree was removed out from under them:
+    the shell's cwd falls back to ``$HOME``. There is nothing to reap but the
+    session itself — no PR, no branch, no worktree — so reaping kills only the
+    tmux session and never touches disk.
+    """
+    return not _is_inside_git_worktree(session.working_dir)
+
+
+def _dead_session_action(session: core.SessionInfo, *, dry_run: bool) -> dict:
+    """Build (and, unless dry-run, perform) the reap of a dead orphan session."""
+    action: dict = {
+        "session": session.name,
+        "branch": "",
+        "pr": None,
+        "pr_state": None,
+        "pr_review": None,
+        "pr_merge_state": None,
+        "last_refresh": None,
+        "killed": False,
+        "worktree_removed": False,
+        "branch_deleted": False,
+        "skipped": False,
+        "reason": "dead-session",
+    }
+    if dry_run:
+        action["action"] = "confirm"
+        return action
+    core.kill_session(session.name)
+    action["killed"] = True
+    return action
+
+
 def _resolve_sessions(
     names: list[str] | None = None,
     *,
@@ -107,12 +153,17 @@ def reap_sessions(
     dry_run: bool = False,
     force: bool = False,
     include_no_pr: bool = False,
+    include_dead: bool = False,
 ) -> list[dict]:
     """Identify and reap sessions whose PRs are merged.
 
     For each session with a branch, queries GitHub PR status.
     MERGED PRs trigger reaping (kill session, remove worktree, delete branch).
     Sessions with uncommitted changes are skipped unless --force.
+
+    With ``include_dead``, bare branchless sessions whose cwd is no longer inside
+    a git work tree (a worktree removed out from under the session) are also
+    reaped — killing the session only, since there is nothing on disk to remove.
 
     Returns list of action dicts.
     """
@@ -123,6 +174,8 @@ def reap_sessions(
         refresh = _refresh_session_pr_metadata(s)
         branch = refresh.get("branch", "")
         if refresh.get("reason") == "no-branch":
+            if include_dead and _is_dead_session(s):
+                results.append(_dead_session_action(s, dry_run=dry_run))
             continue
 
         working_dir = s.working_dir

--- a/tests/test_cli_reap.py
+++ b/tests/test_cli_reap.py
@@ -1,0 +1,102 @@
+"""Tests for the `tp reap` CLI command's preview -> confirm -> reap flow.
+
+These guard against the regression where `tp reap` reaped immediately, before
+(and instead of) prompting, and where the dry-run output listed skipped
+sessions under a misleading "would reap" header.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from tmux_pilot import cli, reaper
+
+
+def _ns(**overrides: object) -> argparse.Namespace:
+    base = dict(dry_run=False, force=False, include_no_pr=False, include_dead=False)
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+_MERGED = {
+    "session": "ltv-22", "branch": "fix/issue-22", "pr": 23,
+    "reason": "pr-merged", "action": "confirm", "skipped": False,
+}
+_OPEN = {
+    "session": "amr", "branch": "feat/amr", "pr": 1458,
+    "reason": "pr-open", "skipped": True,
+}
+
+
+def test_cmd_reap_previews_before_killing_and_aborts(monkeypatch, capsys):
+    calls: list[bool] = []
+
+    def fake_reap(*, dry_run, force, include_no_pr, include_dead):
+        calls.append(dry_run)
+        if dry_run:
+            return [dict(_MERGED)]
+        raise AssertionError("real reap must not run after the user declines")
+
+    monkeypatch.setattr(reaper, "reap_sessions", fake_reap)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+
+    cli.cmd_reap(_ns())
+
+    assert calls == [True]  # only the preview ran; nothing was reaped
+    assert "Aborted" in capsys.readouterr().out
+
+
+def test_cmd_reap_confirm_then_reaps(monkeypatch, capsys):
+    calls: list[bool] = []
+
+    def fake_reap(*, dry_run, force, include_no_pr, include_dead):
+        calls.append(dry_run)
+        if dry_run:
+            return [dict(_MERGED)]
+        return [{"session": "ltv-22", "killed": True, "worktree_removed": True, "branch_deleted": True}]
+
+    monkeypatch.setattr(reaper, "reap_sessions", fake_reap)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    cli.cmd_reap(_ns())
+
+    assert calls == [True, False]  # preview, then the real reap
+    assert "Reaped 1 session(s)." in capsys.readouterr().out
+
+
+def test_cmd_reap_dry_run_separates_reap_from_skip(monkeypatch, capsys):
+    def fake_reap(*, dry_run, force, include_no_pr, include_dead):
+        return [dict(_MERGED), dict(_OPEN)]
+
+    monkeypatch.setattr(reaper, "reap_sessions", fake_reap)
+
+    cli.cmd_reap(_ns(dry_run=True))
+
+    out = capsys.readouterr().out
+    assert "Would reap:" in out
+    assert "Would skip:" in out
+    # the open PR belongs under "skip", not "reap"
+    skip_idx = out.index("Would skip:")
+    assert out.index("ltv-22") < skip_idx
+    assert out.index("amr") > skip_idx
+
+
+def test_cmd_reap_force_skips_prompt(monkeypatch, capsys):
+    calls: list[bool] = []
+
+    def fake_reap(*, dry_run, force, include_no_pr, include_dead):
+        calls.append(dry_run)
+        if dry_run:
+            return [dict(_MERGED)]
+        return [{"session": "ltv-22", "killed": True}]
+
+    def no_input(prompt=""):
+        raise AssertionError("--force must not prompt")
+
+    monkeypatch.setattr(reaper, "reap_sessions", fake_reap)
+    monkeypatch.setattr("builtins.input", no_input)
+
+    cli.cmd_reap(_ns(force=True))
+
+    assert calls == [True, False]
+    assert "Reaped 1 session(s)." in capsys.readouterr().out

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -133,6 +133,63 @@ def test_reap_sessions_include_no_pr(monkeypatch):
     assert results[0]["killed"] is True
 
 
+def test_reap_sessions_ignores_dead_session_without_flag(monkeypatch):
+    # A bare session with no branch is silently skipped unless --include-dead.
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("dismech-drpla")])
+
+    results = reaper.reap_sessions()
+
+    assert results == []
+
+
+def test_reap_sessions_include_dead_flags_bare_session(monkeypatch):
+    # No branch + cwd not inside any git work tree => a dead orphan session.
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("dismech-drpla")])
+    monkeypatch.setattr(reaper, "_is_inside_git_worktree", lambda path: False)
+
+    results = reaper.reap_sessions(dry_run=True, include_dead=True)
+
+    assert len(results) == 1
+    assert results[0]["session"] == "dismech-drpla"
+    assert results[0]["reason"] == "dead-session"
+    assert results[0]["action"] == "confirm"
+    assert results[0]["skipped"] is False
+
+
+def test_reap_sessions_dead_session_kills_session_only(monkeypatch):
+    kill_calls: list[str] = []
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("dismech-drpla")])
+    monkeypatch.setattr(reaper, "_is_inside_git_worktree", lambda path: False)
+    monkeypatch.setattr(reaper.core, "kill_session", lambda name: kill_calls.append(name))
+    # A dead session has no worktree/branch behind it: those ops must never run.
+    monkeypatch.setattr(
+        reaper.core, "_remove_worktree",
+        lambda p: (_ for _ in ()).throw(AssertionError("must not remove worktree")),
+    )
+    monkeypatch.setattr(
+        reaper.core, "_delete_branch",
+        lambda r, b: (_ for _ in ()).throw(AssertionError("must not delete branch")),
+    )
+
+    results = reaper.reap_sessions(include_dead=True)
+
+    assert kill_calls == ["dismech-drpla"]
+    assert results[0]["killed"] is True
+    assert results[0]["worktree_removed"] is False
+    assert results[0]["branch_deleted"] is False
+
+
+def test_reap_sessions_dead_requires_non_worktree(monkeypatch):
+    # A no-branch session that is still inside a work tree (e.g. detached HEAD)
+    # is NOT dead — there may be real work there.
+    monkeypatch.setattr(reaper.core, "list_sessions", lambda **kwargs: [_session("detached")])
+    monkeypatch.setattr(reaper, "_is_inside_git_worktree", lambda path: True)
+
+    results = reaper.reap_sessions(include_dead=True)
+
+    assert results == []
+
+
 def test_refresh_pr_metadata_updates_fields(monkeypatch):
     set_calls: list[tuple[str, str, str]] = []
 


### PR DESCRIPTION
## Summary

Fixes `tp reap` so the CLI always previews candidates before performing destructive cleanup, then only reaps after confirmation or `--force`.

The dry-run output now separates sessions that would be reaped from sessions that would be skipped, which avoids presenting open PRs as reap candidates. It also adds `--include-dead` for explicitly cleaning up branchless sessions whose working directory is no longer inside a Git worktree; those sessions are killed only, with no worktree or branch removal.

## Impact

This reduces the risk of accidental session cleanup and makes `tp reap --dry-run` output more accurate. The new dead-session path is opt-in so existing default behavior remains conservative.

## Validation

- `uv run pytest tests/test_cli_reap.py tests/test_reaper.py`
- `uv run ruff check src/tmux_pilot/cli.py src/tmux_pilot/reaper.py tests/test_cli_reap.py tests/test_reaper.py`
