### PR TITLE
[codex] increase worktree add timeout

### DIFF
--- a/src/tmux_pilot/core.py
+++ b/src/tmux_pilot/core.py
@@ -64,6 +64,7 @@ _DEFAULT_CLONE_BASE = "~/repos"
 _DEFAULT_WORKTREE_BASE = "~/worktrees"
 _SEND_KEYS_SETTLE_DELAY = 0.1
 _CWD_VERIFY_TIMEOUT = 2.0
+_WORKTREE_ADD_TIMEOUT = 180
 _CWD_VERIFY_INTERVAL = 0.05
 _PI_SESSION_DIR_TEMPLATE = "{worktree}/.tmux-pilot/pi/sessions"
 _BUILTIN_PROFILE_DEFS: dict[str, dict[str, object]] = {
@@ -1142,11 +1143,15 @@ def _prepare_worktree(repo_path: str, *, worktree_dir: Path, branch: str, base_r
         raise RuntimeError(f"Worktree path already exists: {worktree_dir}")
 
     if _local_branch_exists(repo_path, branch):
-        _git(["worktree", "add", str(worktree_dir), branch], cwd=repo_path)
+        _git(["worktree", "add", str(worktree_dir), branch], cwd=repo_path, timeout=_WORKTREE_ADD_TIMEOUT)
         return
 
     _fetch_base_ref(repo_path, base_ref)
-    _git(["worktree", "add", "-b", branch, str(worktree_dir), base_ref], cwd=repo_path)
+    _git(
+        ["worktree", "add", "-b", branch, str(worktree_dir), base_ref],
+        cwd=repo_path,
+        timeout=_WORKTREE_ADD_TIMEOUT,
+    )
 
 
 class _TemplateDict(dict[str, str]):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -434,6 +434,86 @@ def test_resolve_repo_source_clones_github_repo_when_missing(monkeypatch, tmp_pa
     ]
 
 
+def test_prepare_worktree_uses_long_timeout_for_existing_branch(monkeypatch, tmp_path):
+    git_calls: list[tuple[list[str], str, int]] = []
+
+    def fake_git(
+        args: list[str],
+        *,
+        cwd: str,
+        check: bool = True,
+        timeout: int = 15,
+    ) -> str:
+        del check
+        git_calls.append((args, cwd, timeout))
+        return ""
+
+    monkeypatch.setattr(core, "_local_branch_exists", lambda repo_path, branch: True)
+    monkeypatch.setattr(core, "_git", fake_git)
+
+    core._prepare_worktree(
+        "/repo",
+        worktree_dir=tmp_path / "large-repo-worktree",
+        branch="feat/large-repo-worktree",
+        base_ref="origin/main",
+    )
+
+    assert git_calls == [
+        (
+            ["worktree", "add", str(tmp_path / "large-repo-worktree"), "feat/large-repo-worktree"],
+            "/repo",
+            core._WORKTREE_ADD_TIMEOUT,
+        )
+    ]
+
+
+def test_prepare_worktree_uses_long_timeout_for_new_branch(monkeypatch, tmp_path):
+    git_calls: list[tuple[list[str], str, int]] = []
+    fetched_base_refs: list[tuple[str, str]] = []
+
+    def fake_git(
+        args: list[str],
+        *,
+        cwd: str,
+        check: bool = True,
+        timeout: int = 15,
+    ) -> str:
+        del check
+        git_calls.append((args, cwd, timeout))
+        return ""
+
+    monkeypatch.setattr(core, "_local_branch_exists", lambda repo_path, branch: False)
+    monkeypatch.setattr(
+        core,
+        "_fetch_base_ref",
+        lambda repo_path, base_ref: fetched_base_refs.append((repo_path, base_ref)),
+    )
+    monkeypatch.setattr(core, "_git", fake_git)
+
+    core._prepare_worktree(
+        "/repo",
+        worktree_dir=tmp_path / "large-repo-worktree",
+        branch="feat/large-repo-worktree",
+        base_ref="origin/main",
+    )
+
+    assert fetched_base_refs == [("/repo", "origin/main")]
+    assert git_calls == [
+        (
+            [
+                "worktree",
+                "add",
+                "-b",
+                "feat/large-repo-worktree",
+                str(tmp_path / "large-repo-worktree"),
+                "origin/main",
+            ],
+            "/repo",
+            core._WORKTREE_ADD_TIMEOUT,
+        )
+    ]
+
+
 def test_list_sessions_detects_branch_from_worktree(monkeypatch):
     monkeypatch.setattr(core, "tmux_running", lambda: True)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Increases the timeout used by `git worktree add` during `tp new` worktree preparation from the default short Git wrapper timeout to a dedicated 180-second timeout.

This applies to both existing local branch worktrees and new branch worktrees after the base ref has been fetched.

## Impact

Large repositories or slower filesystems get more time to create the worktree before `tp new` fails, while other Git operations keep their existing default timeout.

## Validation

- `uv run pytest tests/test_profiles.py`
- `uv run ruff check src/tmux_pilot/core.py tests/test_profiles.py`
