### PR TITLE
[codex] add install-tool recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,11 @@ ci: lint typecheck test
 install:
     uv sync
 
+install-tool:
+    rm -f dist/tmux_pilot-*.whl
+    uv build --wheel
+    uv tool install --force dist/tmux_pilot-*.whl
+
 build:
     uv build
 


### PR DESCRIPTION
## Summary

Adds a `just install-tool` recipe that removes stale built wheels, builds a fresh wheel, and force-installs it with `uv tool install`.

## Impact

This gives maintainers a single local command for rebuilding and reinstalling the CLI as a uv tool during development.

## Validation

- `just --list`
