### PR TITLE
Add tmux-pilot Claude Code plugin and marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "tmux-pilot",
+  "owner": {
+    "name": "Chris Mungall"
+  },
+  "description": "Marketplace for the tmux-pilot Claude Code plugin.",
+  "plugins": [
+    {
+      "name": "tmux-pilot",
+      "source": "./plugins/tmux-pilot",
+      "description": "Orchestrate tmux sessions for AI coding agents with the tmux-pilot `tp` CLI.",
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ Detailed documentation also lives under [`docs/`](./docs/overview.md) and is org
 - reference: [`docs/reference/agent-state.md`](./docs/reference/agent-state.md)
 - reference: [`docs/reference/session-creation.md`](./docs/reference/session-creation.md)
 
+## Claude Code Plugin
+
+This repo ships a Claude Code plugin that bundles the `tmux-pilot` [Agent Skill](https://agentskills.io/specification). The skill teaches Claude to use the `tp` CLI to start, inspect, steer, resume, refresh PR metadata for, and clean up agent sessions and git worktrees.
+
+- plugin: [`plugins/tmux-pilot`](./plugins/tmux-pilot)
+- repo marketplace: [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json)
+
+Install from GitHub:
+
+```
+/plugin marketplace add cmungall/tmux-pilot
+/plugin install tmux-pilot@tmux-pilot
+```
+
+Or from a local checkout (run from the repo root):
+
+```
+/plugin marketplace add ./
+/plugin install tmux-pilot@tmux-pilot
+```
+
+The `SKILL.md` follows the portable Agent Skills spec, so it can also be loaded directly by other skill-aware agents (e.g. Codex via `~/.agents/skills/`).
+
 ## Commands
 
 ### `tp ls` — List sessions

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ uv tool install tmux-pilot
 
 **Requirements:** Python 3.10+, tmux. Optional: fzf (for `tp jump` picker).
 
+### Claude Code skill
+
+To teach Claude Code to drive `tp`, install the bundled skill from this repo's plugin marketplace:
+
+```
+/plugin marketplace add cmungall/tmux-pilot
+/plugin install tmux-pilot@tmux-pilot
+```
+
+This adds the `tmux-pilot` Agent Skill that Claude invokes when you ask it to start, inspect, steer, resume, or clean up agent sessions. See [Claude Code Plugin](#claude-code-plugin) below for details and local-checkout install.
+
 ## Quick Start
 
 ```bash

--- a/plugins/tmux-pilot/.claude-plugin/plugin.json
+++ b/plugins/tmux-pilot/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "tmux-pilot",
+  "description": "Orchestrate tmux sessions for AI coding agents with the tmux-pilot `tp` CLI: start, inspect, steer, resume, refresh PR metadata for, and clean up sessions and git worktrees.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Chris Mungall"
+  },
+  "homepage": "https://cmungall.github.io/tmux-pilot/",
+  "repository": "https://github.com/cmungall/tmux-pilot",
+  "license": "MIT",
+  "keywords": [
+    "tmux",
+    "agents",
+    "worktrees",
+    "orchestration",
+    "claude-code"
+  ]
+}

--- a/plugins/tmux-pilot/skills/tmux-pilot/SKILL.md
+++ b/plugins/tmux-pilot/skills/tmux-pilot/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: tmux-pilot
+description: Use the tmux-pilot `tp` CLI to orchestrate tmux sessions for AI coding agents. Use when the user wants to start, inspect, attach to, send instructions to, resume, refresh PR metadata for, or clean up Codex, Claude Code, Pi, or generic tmux-backed task sessions and git worktrees.
+---
+
+# Tmux Pilot
+
+## Overview
+
+Use `tp` as the front door for managing long-running AI coding-agent sessions in tmux. Prefer `tp` over raw `tmux` when the task involves session metadata, git worktrees, PR state, agent readiness, or cleanup.
+
+## Preflight
+
+Run these checks before depending on `tp`:
+
+```bash
+tp --version
+tmux -V
+tp ls --json
+```
+
+If `tp` is missing, suggest installing it with one of:
+
+```bash
+uv tool install tmux-pilot
+pipx install tmux-pilot
+pip install tmux-pilot
+```
+
+When operating inside a repository, check the local worktree first:
+
+```bash
+git status -sb
+```
+
+Do not run destructive cleanup commands without a preview unless the user explicitly requested forceful cleanup.
+
+## Start Sessions
+
+Choose the startup pattern that matches the user's intent.
+
+Existing checkout:
+
+```bash
+tp new docs-pass --profile codex -c ~/repos/myapp
+tp new review-pass --profile claude -c ~/repos/myapp
+tp new pi-local --profile pi -c ~/repos/pi-mono
+```
+
+Task branch and worktree bootstrap:
+
+```bash
+tp new oauth-fix --profile codex --repo ~/repos/myapp
+tp new issue-771 --profile claude --repo ~/repos/myapp --issue 771
+tp new pi-smoke --profile pi --repo badlogic/pi-mono
+```
+
+Useful overrides:
+
+```bash
+tp new cleanup --profile codex --repo ~/repos/myapp --branch chore/cleanup
+tp new backport --profile codex --repo ~/repos/myapp --base-ref origin/release/1.2
+tp new triage-pass --profile codex --repo ~/repos/myapp --no-agent
+tp new parser-pass -c ~/repos/myapp --agent "codex --profile yolo --no-alt-screen"
+tp new shell-pass -c ~/repos/myapp --agent zsh
+```
+
+Use `--prompt` only when the initial instruction is ready to send after the agent starts:
+
+```bash
+tp new docs-pass --profile codex -c ~/repos/myapp --prompt "summarize the docs layout"
+```
+
+## Inspect And Steer
+
+Use non-invasive inspection before attaching:
+
+```bash
+tp ls
+tp ls --cols NAME,PR,STATUS,DIR
+tp peek docs-pass -n 80
+tp status docs-pass
+tp trace docs-pass
+```
+
+Send follow-up work with readiness checks when possible:
+
+```bash
+tp send --wait docs-pass "continue with the next failing test"
+tp send --wait --timeout 120 docs-pass "address the review comments and push fixes"
+```
+
+Use `tp jump docs-pass` only when the user wants an interactive attach/switch.
+
+## PR Metadata And Production Prompts
+
+Refresh PR metadata before making a dashboard or sending PR-driven follow-ups:
+
+```bash
+tp refresh --repo myapp
+tp ls --cols NAME,PR,STATUS,DIR --repo myapp
+tp ls --all-metadata --repo myapp
+```
+
+Use `tp prod --dry-run` before sending configured follow-up prompts:
+
+```bash
+tp prod --dry-run --repo myapp
+tp prod --repo myapp --wait
+```
+
+`tp refresh` writes cached metadata but does not kill sessions, remove worktrees, or delete branches.
+
+## Resume Worktrees
+
+When tmux sessions are gone but worktrees remain:
+
+```bash
+tp wt status
+tp wt ls --repo myapp
+tp wt refresh --repo myapp
+tp wt resume oauth-fix --dry-run
+tp wt resume oauth-fix --profile codex
+tp wt resume oauth-fix -c
+```
+
+Use `-c/--continue` when the detected agent supports resuming the previous conversation.
+
+## Cleanup
+
+Always preview first:
+
+```bash
+tp clean --dry-run
+tp reap --dry-run
+tp wt clean
+```
+
+Apply cleanup only after confirmation or explicit user instruction:
+
+```bash
+tp clean --force
+tp reap --force
+tp wt clean --force
+```
+
+Use `tp reap` for PR-aware cleanup after branches land. Use `tp reap --include-dead` only when intentionally cleaning branchless sessions whose worktree has disappeared; it kills the tmux session only.
+
+## Output Expectations
+
+Report:
+
+- session names created, inspected, resumed, or removed
+- worktree paths and branches when `--repo` bootstrapping is used
+- prompts sent to agents
+- whether commands were dry-run previews or destructive actions
+- any blockers, such as missing `tp`, missing `tmux`, dirty worktrees, trust prompts, or agent readiness timeouts


### PR DESCRIPTION
## Summary

Repackages the `tmux-pilot` skill (originally scaffolded as a Codex plugin) into a **Claude Code plugin** distributable via a repo marketplace. The skill's `SKILL.md` follows the portable [Agent Skills spec](https://agentskills.io/specification), so it remains loadable by other skill-aware agents too.

### Added
- `plugins/tmux-pilot/skills/tmux-pilot/SKILL.md` — skill teaching the `tp` CLI: start, inspect, steer, resume, refresh PR metadata, and clean up agent sessions / git worktrees.
- `plugins/tmux-pilot/.claude-plugin/plugin.json` — Claude plugin manifest (spec fields: `name`, `description`, `version`, `author`, `homepage`, `repository`, `license`, `keywords`).
- `.claude-plugin/marketplace.json` — repo marketplace catalog (`source: ./plugins/tmux-pilot`).

### Changed
- `README.md` — "Codex Skill" section replaced with "Claude Code Plugin" + `/plugin` install instructions.

### Removed
- Codex-specific packaging: `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and the skill's `agents/openai.yaml`. (These were never committed to `main`.)

## Install

```
/plugin marketplace add cmungall/tmux-pilot
/plugin install tmux-pilot@tmux-pilot
```

## Verification
- `claude plugin validate .` → marketplace passed
- `claude plugin validate ./plugins/tmux-pilot` → plugin passed
- End-to-end local install/uninstall: skill discovered and namespaced as `tmux-pilot:tmux-pilot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)